### PR TITLE
teralynx sonic 202211 patch script update for SAI 3.1.3 release

### DIFF
--- a/files/202211/0001-marvell-x86-syncd-docker-TL10-and-SAI-inclusions.patch
+++ b/files/202211/0001-marvell-x86-syncd-docker-TL10-and-SAI-inclusions.patch
@@ -1,7 +1,7 @@
-From 5a2f9b27cf47737bb5a3fb4bde37e706b37cf67b Mon Sep 17 00:00:00 2001
+From 99ee15e12fdb75b337aedd7e545b46fc7ac3bbd5 Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Thu, 30 Nov 2023 05:18:18 -0800
-Subject: [PATCH 1/6] marvell-x86-syncd-docker-TL10-and-SAI-inclusions
+Subject: [PATCH 1/8] marvell-x86-syncd-docker-TL10-and-SAI-inclusions
 
 Signed-off-by: builder <ksridharan@marvell.com>
 ---
@@ -197,5 +197,5 @@ index 39e695575..57770300f 100755
  
  # Runtime dependency on invm sai is set only for syncd
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0002-marvell-Backport-of-master-PR-14589-to-202211-branch.patch
+++ b/files/202211/0002-marvell-Backport-of-master-PR-14589-to-202211-branch.patch
@@ -1,14 +1,14 @@
-From d1dae55fad61a07c7e9a91fb0afbd71560bfc748 Mon Sep 17 00:00:00 2001
+From 9cdaa3d43934b98582d088507b4cd1aab5f231db Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Thu, 30 Nov 2023 05:19:01 -0800
-Subject: [PATCH 2/6] marvell-Backport-of-master-PR-#14589-to-202211-branch
+Subject: [PATCH 2/8] marvell-Backport-of-master-PR-#14589-to-202211-branch
 
 ---
  installer/default_platform.conf | 30 ++++++++++++++----------------
  1 file changed, 14 insertions(+), 16 deletions(-)
 
 diff --git a/installer/default_platform.conf b/installer/default_platform.conf
-index b0fbff2e1..f744eccd8 100755
+index 4f356cf0f..d14025cc0 100755
 --- a/installer/default_platform.conf
 +++ b/installer/default_platform.conf
 @@ -434,14 +434,23 @@ bootloader_menu_config()
@@ -67,5 +67,5 @@ index b0fbff2e1..f744eccd8 100755
  
      echo "Installed SONiC base image $demo_volume_label successfully"
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0003-marvell-backport-master-PR-12653-innovium-platform-f.patch
+++ b/files/202211/0003-marvell-backport-master-PR-12653-innovium-platform-f.patch
@@ -1,7 +1,7 @@
-From d770db1371cf78d95440a01ae09448db3f7cd4df Mon Sep 17 00:00:00 2001
+From abc211c2a9dde081115dba89b93804a7fc372d84 Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Thu, 30 Nov 2023 17:23:00 -0800
-Subject: [PATCH 3/6] marvell-backport-master-PR#12653-innovium-platform-files
+Subject: [PATCH 3/8] marvell-backport-master-PR#12653-innovium-platform-files
 
 ---
  .../docker-syncd-invm/critical_processes      |  1 +
@@ -77,5 +77,5 @@ index 000000000..32bdb12eb
 +   /usr/bin/ivm_start.sh
 +fi
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0004-marvell-midstone-Compilation-Error-in-master-branch-.patch
+++ b/files/202211/0004-marvell-midstone-Compilation-Error-in-master-branch-.patch
@@ -1,7 +1,7 @@
-From e231590abf24d0cfdfbe474a86e7a9615f7f88d3 Mon Sep 17 00:00:00 2001
+From aec69554ce00603f6c6d5b2fdb54c738c714f0fe Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Thu, 30 Nov 2023 19:33:22 -0800
-Subject: [PATCH 4/6] marvell-midstone Compilation Error in master branch
+Subject: [PATCH 4/8] marvell-midstone Compilation Error in master branch
  #14826
 
 ---
@@ -22,5 +22,5 @@ index a391056d0..002172f58 100755
                  return -ENOMEM;
  
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0005-marvell-platform-and-hwsku-files-for-wistron-and-cel.patch
+++ b/files/202211/0005-marvell-platform-and-hwsku-files-for-wistron-and-cel.patch
@@ -1,7 +1,7 @@
-From 61b670ebc69a3ef05761b3eda322e68b472b0518 Mon Sep 17 00:00:00 2001
+From 6b018fff3a7d281f69622b2e3ed9b23b91aad60c Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Thu, 30 Nov 2023 21:03:13 -0800
-Subject: [PATCH 5/6] marvell: platform and hwsku files for wistron and
+Subject: [PATCH 5/8] marvell: platform and hwsku files for wistron and
  celestica
 
 ---
@@ -18573,5 +18573,5 @@ index 46121e6e7..c7b65e16e 100644
  
  def do_uninstall():
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0006-marvell-bullseye-migration-for-innovium.patch
+++ b/files/202211/0006-marvell-bullseye-migration-for-innovium.patch
@@ -1,7 +1,7 @@
-From 18294bd40daa78a5fd362b91c4c624b62ac9cb66 Mon Sep 17 00:00:00 2001
+From b9ee43b7a6e32a01598b1bb76cdff0c604cf6186 Mon Sep 17 00:00:00 2001
 From: builder <ksridharan@marvell.com>
 Date: Wed, 10 Jan 2024 03:53:59 -0800
-Subject: [PATCH 6/6] marvell: bullseye migration for innovium
+Subject: [PATCH 6/8] marvell: bullseye migration for innovium
 
 ---
  platform/innovium/docker-syncd-invm-rpc.mk            |  1 +
@@ -93,5 +93,5 @@ index a19109be4..aa608b1de 100755
  ARG docker_container_name
  
 -- 
-2.25.1
+2.17.1
 

--- a/files/202211/0007-marvell-teralynx-Use-the-archive-repo-for-Buster-186.patch
+++ b/files/202211/0007-marvell-teralynx-Use-the-archive-repo-for-Buster-186.patch
@@ -1,0 +1,27 @@
+From 167a69758f843671ddd0d8d309e443dc545501dd Mon Sep 17 00:00:00 2001
+From: ksridharan <ksridharan@marvell.com>
+Date: Tue, 16 Apr 2024 03:05:04 -0700
+Subject: [PATCH 7/8]  marvell-teralynx-Use the archive repo for Buster #18678
+
+---
+ scripts/build_mirror_config.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scripts/build_mirror_config.sh b/scripts/build_mirror_config.sh
+index bd5312c1b..120640fe1 100755
+--- a/scripts/build_mirror_config.sh
++++ b/scripts/build_mirror_config.sh
+@@ -21,6 +21,10 @@ if [ "$ARCHITECTURE" == "armhf" ]; then
+     DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/
+ fi
+ 
++if [ "$DISTRIBUTION" == "buster" ]; then
++    DEFAULT_MIRROR_URLS=http://archive.debian.org/debian/
++fi
++
+ if [ "$MIRROR_SNAPSHOT" == y ]; then
+     if [ -f "$MIRROR_VERSION_FILE" ]; then
+         DEBIAN_TIMESTAMP=$(grep "^debian==" $MIRROR_VERSION_FILE | tail -n 1 | sed 's/.*==//')
+-- 
+2.17.1
+

--- a/files/202211/0008-marvell-teralynx-Add-SDK-dependent-python-packages-1.patch
+++ b/files/202211/0008-marvell-teralynx-Add-SDK-dependent-python-packages-1.patch
@@ -1,0 +1,24 @@
+From f3e499f2a98a823b3f392397a2ce08cef7a0cac7 Mon Sep 17 00:00:00 2001
+From: ksridharan <ksridharan@marvell.com>
+Date: Fri, 19 Apr 2024 20:45:19 -0700
+Subject: [PATCH 8/8] marvell-teralynx-Add SDK dependent python packages #18232
+
+---
+ platform/innovium/docker-syncd-invm/Dockerfile.j2 | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/platform/innovium/docker-syncd-invm/Dockerfile.j2 b/platform/innovium/docker-syncd-invm/Dockerfile.j2
+index aa608b1de..f477c3d9b 100755
+--- a/platform/innovium/docker-syncd-invm/Dockerfile.j2
++++ b/platform/innovium/docker-syncd-invm/Dockerfile.j2
+@@ -20,6 +20,7 @@ RUN apt-get install -y libjansson4
+ RUN apt-get install -y libyaml-dev
+ RUN apt-get install -y binutils
+ RUN pip3 install numpy
++RUN pip3 install yamlordereddictloader
+ 
+ RUN dpkg -i \
+ {% for deb in docker_syncd_invm_debs.split(' ') -%}
+-- 
+2.17.1
+

--- a/sonic_202211_apply_patch_teralynx.sh
+++ b/sonic_202211_apply_patch_teralynx.sh
@@ -12,7 +12,7 @@
 # CONFIGURATIONS:-
 #
 
-SONIC_COMMIT="795ac1a751ac8a8b29cd35b4228c039beec3e771"
+SONIC_COMMIT="5500dc47d1178555a4807b566b0ff29bc3844f28"
 
 #
 # END of CONFIGURATIONS
@@ -24,7 +24,7 @@ LOG_FILE=patches_result.log
 FULL_PATH=`pwd`
 
 # Path for 202211 patches
-WGET_PATH="https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_02/files/202211/"
+WGET_PATH="https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_03/files/202211/"
 
 # Patches
 SERIES="0001-marvell-x86-syncd-docker-TL10-and-SAI-inclusions.patch
@@ -32,7 +32,9 @@ SERIES="0001-marvell-x86-syncd-docker-TL10-and-SAI-inclusions.patch
         0003-marvell-backport-master-PR-12653-innovium-platform-f.patch
         0004-marvell-midstone-Compilation-Error-in-master-branch-.patch
         0005-marvell-platform-and-hwsku-files-for-wistron-and-cel.patch
-        0006-marvell-bullseye-migration-for-innovium.patch"
+        0006-marvell-bullseye-migration-for-innovium.patch
+	0007-marvell-teralynx-Use-the-archive-repo-for-Buster-186.patch
+	0008-marvell-teralynx-Add-SDK-dependent-python-packages-1.patch"
 
 PATCHES=""
 
@@ -67,7 +69,7 @@ apply_patch_series()
     do
         echo $patch
         pushd patches
-        wget -c $WGET_PATH/$patch
+        wget -c --timeout=2 $WGET_PATH/$patch
         popd
         git am patches/$patch
         if [ $? -ne 0 ]; then
@@ -83,7 +85,7 @@ apply_patches()
     do
 	echo $patch
     	pushd patches
-    	wget -c $WGET_PATH/$patch
+        wget -c --timeout=2 $WGET_PATH/$patch
         popd
 	    patch -p1 < patches/$patch
         if [ $? -ne 0 ]; then
@@ -102,7 +104,7 @@ apply_submodule_patches()
 	dir=${SP}[DIR]
 	echo "${!patch}"
     	pushd patches
-    	wget -c $WGET_PATH/${!patch}
+        wget -c --timeout=2 $WGET_PATH/${!patch}
         popd
 	    pushd ${!dir}
         git am $CWD/patches/${!patch}
@@ -117,8 +119,8 @@ apply_submodule_patches()
 apply_hwsku_changes()
 {
     # Download hwsku
-    wget -c https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_02/files/mrvl_sonic_hwsku_dbmvtx9180.tgz
-    wget -c https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_02/files/mrvl_sonic_platform_dbmvtx9180.tgz
+    wget -c --timeout=2 https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_03/files/mrvl_sonic_hwsku_dbmvtx9180.tgz
+    wget -c --timeout=2 https://raw.githubusercontent.com/Marvell-switching/sonic-scripts/tl_03/files/mrvl_sonic_platform_dbmvtx9180.tgz
 
     rm -fr device/marvell/x86_64-marvell_dbmvtx9180-r0 || true
     rm -fr platform/innovium/sonic-platform-modules-marvell || true


### PR DESCRIPTION
Patch script update for teralynx SAI 3.1.3 release in sonic 202211 branch
1. commit id SHA value updated to latest tested commit id
2. Added sonic master community patches needed for two different issues.
  - SOniC PR #18678 - community buster build breakage issue
  - SONIC PR #18232 - Teralynx specific platform commit for fixing an SDK package