### PR TITLE
Marvell prestera fw setenv with without f

### DIFF
--- a/files/master/0001-platform-marvell-prestera-fw_setenv-with-without-f.patch
+++ b/files/master/0001-platform-marvell-prestera-fw_setenv-with-without-f.patch
@@ -1,0 +1,68 @@
+From b1b092adcdbc05da0cf8784184fb19b38824c179 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Wed, 14 May 2025 09:28:18 +0000
+Subject: [PATCH 1/1] platform marvell-prestera: fw_setenv with without -f
+
+The utility fw_setenv is present in bin-self-extracting installation
+script used by SONiC upgrade and ONIE installation.
+
+UBOOT-ONIE arm64/armhf fw_setenv vs SONiC have different versions.
+Even between UBOOT-ONIE the versions could be different.
+The main difference is "Interactive" vs "direct set" behavior.
+
+Note: Irrelevant for Intel/amd64/GRUB ONIE.
+
+INTERACTIVE
+  fw_setenv varName val
+    Proceed with update [N/y]
+To eliminate this interactive [N/y] the -f option should be present
+  fw_setenv -f varName val
+
+Non-Interactive version "direct set" should NOT use the '-f'
+  fw_setenv varName val
+
+This patch tests the real running behavior and acts with or without '-f'
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ platform/marvell-prestera/platform_arm64.conf | 6 +++++-
+ platform/marvell-prestera/platform_armhf.conf | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/platform/marvell-prestera/platform_arm64.conf b/platform/marvell-prestera/platform_arm64.conf
+index 617ab6ab9..9200ad3de 100644
+--- a/platform/marvell-prestera/platform_arm64.conf
++++ b/platform/marvell-prestera/platform_arm64.conf
+@@ -192,7 +192,11 @@ prepare_boot_menu() {
+     fit_name=${image_dir}${fit_fname}
+ 
+     if [ "$install_env" = "onie" ]; then
+-        FW_ARG="-f"
++        TMP_OUTPUT=$(echo | fw_setenv z 1 2>&1)
++        #Proceed with update [N/y] (do not use grep -w)
++        if echo "$TMP_OUTPUT" | grep -qi "y"; then
++            FW_ARG="-f"
++        fi
+         fw_setenv ${FW_ARG} image_dir_old "" > /dev/null
+         fw_setenv ${FW_ARG} image_name_old "" > /dev/null
+         fw_setenv ${FW_ARG} initrd_name_old "" > /dev/null
+diff --git a/platform/marvell-prestera/platform_armhf.conf b/platform/marvell-prestera/platform_armhf.conf
+index dd7c972b9..72cb19e06 100644
+--- a/platform/marvell-prestera/platform_armhf.conf
++++ b/platform/marvell-prestera/platform_armhf.conf
+@@ -127,7 +127,11 @@ prepare_boot_menu() {
+ 
+ 
+     if [ "$install_env" = "onie" ]; then
+-        FW_ARG="-f"
++        TMP_OUTPUT=$(echo | fw_setenv z 1 2>&1)
++        #Proceed with update [N/y] (do not use grep -w)
++        if echo "$TMP_OUTPUT" | grep -qi "y"; then
++            FW_ARG="-f"
++        fi
+         image_dir_old=""
+         image_name_old=""
+         initrd_name_old=""
+-- 
+2.25.1
+

--- a/files/master/series_marvell-prestera_arm64
+++ b/files/master/series_marvell-prestera_arm64
@@ -1,2 +1,3 @@
 0001-buildimage-print-each-build-target-on-separated-line.patch|sonic-buildimage
 0001-marvell-prestera-rename-orchagent.patch|sonic-buildimage
+0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage

--- a/files/master/series_marvell-prestera_armhf
+++ b/files/master/series_marvell-prestera_armhf
@@ -1,2 +1,3 @@
 0001-buildimage-print-each-build-target-on-separated-line.patch|sonic-buildimage
 0001-marvell-prestera-rename-orchagent.patch|sonic-buildimage
+0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage


### PR DESCRIPTION
marvell-prestera: fw_setenv with without -f

The utility fw_setenv is present in bin-self-extracting installation
script used by SONiC upgrade and ONIE installation.

UBOOT-ONIE arm64/armhf fw_setenv vs SONiC have different versions.
Even between UBOOT-ONIE the versions could be different.
The main difference is "Interactive" vs "direct set" behavior.

Note: Irrelevant for Intel/amd64/GRUB ONIE.

INTERACTIVE
  fw_setenv varName val
    Proceed with update [N/y]
To eliminate this interactive [N/y] the -f option should be present
  fw_setenv -f varName val

Non-Interactive version "direct set" should NOT use the '-f'
  fw_setenv varName val

This patch tests the real running behavior and acts with or without '-f'
