### PR TITLE
platform:prestera: fix support for AC5P-RD mmcblk

### DIFF
--- a/files/master/0002-platform-prestera-fix-support-for-AC5P-RD-mmcblk.patch
+++ b/files/master/0002-platform-prestera-fix-support-for-AC5P-RD-mmcblk.patch
@@ -1,0 +1,124 @@
+From c1091e353089ef9134d2129377f2b36d663dfc07 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Thu, 22 May 2025 14:10:19 +0300
+Subject: [PATCH] platform:prestera: fix support for AC5P-RD mmcblk
+
+Why I did it
+AC5P-RD (arm64-marvell_rd98DX45xx_cn9131-r0) may have
+disk scsi or mmcblk, but only scsi is handled.
+On the "sonic-installer install" action the blk_dev is empty
+instead of "blk_dev=/dev/mmcblk0"
+leading to wrong Uboot env parameters
+  sonic_boot_load= ... mmc 0: ...
+  sonic_boot_load_old= ... mmc 0: ...
+instead of correct "mmc 0:2"
+The further reboot fails with
+  Wrong Image Format for bootm command
+  ERROR: can't get kernel image!
+
+How I did it
+Add mmc_bus="mmc0:0001" and use in get_install_device()
+as last default.
+
+How to test
+sonic-installer install sonic-marvell-prestera-arm64.bin; reboot
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+
+diff --git a/platform/marvell-prestera/platform_arm64.conf b/platform/marvell-prestera/platform_arm64.conf
+index 32d60fcc9..2df8a4974 100644
+--- a/platform/marvell-prestera/platform_arm64.conf
++++ b/platform/marvell-prestera/platform_arm64.conf
+@@ -1,6 +1,8 @@
+ #  Copyright (C) Marvell Inc
+ 
+-# over ride default behaviour
++# On ONIE runs in 'sh' but not in 'bash'
++
++# override default behavior
+ 
+ echo "Preparing for installation ... "
+ 
+@@ -30,21 +32,25 @@ disk_interface="mmc"
+ 
+ case $PLATFORM in
+     arm64-nokia_ixs7215_52xb-r0) PLATFORM_7215_A1=1;
+-		mmc_bus="mmc0:0001";
+-		fdt_fname="/usr/lib/linux-image-${kernel_version}/marvell/7215-ixs-a1.dtb";
+-		fit_conf_name="#conf_7215_a1";;
++        mmc_bus="mmc0:0001";
++        fdt_fname="/usr/lib/linux-image-${kernel_version}/marvell/7215-ixs-a1.dtb";
++        fit_conf_name="#conf_7215_a1";;
+     arm64-marvell_rd98DX35xx-r0) PLATFORM_AC5X=1;
+-		mmc_bus="mmc0:0001";
+-		fdt_fname="/usr/lib/linux-image-$kernel_version/marvell/ac5-98dx35xx-rd.dtb";
+-		fit_conf_name="#conf_ac5x";;
++        mmc_bus="mmc0:0001";
++        fdt_fname="/usr/lib/linux-image-$kernel_version/marvell/ac5-98dx35xx-rd.dtb";
++        fit_conf_name="#conf_ac5x";;
+     arm64-marvell_rd98DX35xx_cn9131-r0) PLATFORM_CN9131=1;
+-		mmc_bus="mmc0:0001";
+-		fdt_fname="/boot/cn9131-db-comexpress.dtb";
+-		fit_conf_name="#conf_cn9131";;
++        mmc_bus="mmc0:0001";
++        fdt_fname="/boot/cn9131-db-comexpress.dtb";
++        fit_conf_name="#conf_cn9131";;
+     arm64-marvell_rd98DX45xx_cn9131-r0) PLATFORM_CN9131=1;
+-                scsi_bus="1:0:0:0";
+-                fdt_fname="/boot/cn9131-db-comexpress.dtb";
+-                fit_conf_name="#conf_cn9131";;
++        scsi_bus="1:0:0:0";
++        if [ "$install_env" != "onie" ]; then
++            # Either scsi or default mmc/eMMC must be present
++            mmc_bus="mmc0:0001";
++        fi
++        fdt_fname="/boot/cn9131-db-comexpress.dtb";
++        fit_conf_name="#conf_cn9131";;
+ esac
+ 
+ if [ $PLATFORM_AC5X -eq 1 ]; then
+@@ -79,21 +85,9 @@ LINUX_MISC_CMD='apparmor=1 security=apparmor usbcore.autosuspend=-1'
+ 
+ # Get block device
+ # default_platform.conf will by default install SONIC on same block device as ONIE
+-# This funtion looks to override SONIC install target disk, with optional eMMC or SCSI disk.
++# This function looks to override SONIC install target disk, with optional eMMC or SCSI disk.
+ get_install_device()
+ {
+-    if [ ! -z "$mmc_bus" ]; then
+-        for i in 0 1 2 ; do
+-            if $(ls -l /sys/block/mmcblk$i/device 2>/dev/null | grep -q "$mmc_bus") ; then
+-                echo "/dev/mmcblk$i"
+-                blk_dev=/dev/mmcblk$i
+-                disk_interface="mmc"
+-                echo "Selected mmc $blk_dev"
+-                return
+-            fi
+-        done
+-    fi
+-
+     if [ ! -z "$scsi_bus" ]; then
+         for i in a b c d ; do
+             if $(ls -l /sys/block/sd$i/device 2>/dev/null | grep -q "$scsi_bus") ; then
+@@ -107,6 +101,18 @@ get_install_device()
+         done
+     fi
+ 
++    if [ ! -z "$mmc_bus" ]; then
++        for i in 0 1 2 ; do
++            if $(ls -l /sys/block/mmcblk$i/device 2>/dev/null | grep -q "$mmc_bus") ; then
++                echo "/dev/mmcblk$i"
++                blk_dev=/dev/mmcblk$i
++                disk_interface="mmc"
++                echo "Selected mmc $blk_dev"
++                return
++            fi
++        done
++    fi
++
+     echo "Waring: Storage not found. Will try installing on the same disk as ONIE."
+ }
+ 
+-- 
+2.25.1
+

--- a/files/master/series_marvell-prestera_arm64
+++ b/files/master/series_marvell-prestera_arm64
@@ -3,6 +3,7 @@
 0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage
 21506-submodule-sonic-platform-marvell-add-AC5P-marvell_rd.patch|sonic-buildimage
 21506-add-AC5P-marvell_rd98DX45xx_cn9131.patch|sonic-buildimage
+0002-platform-prestera-fix-support-for-AC5P-RD-mmcblk.patch|sonic-buildimage
 0011-arm64-kdump-support-Install-kdump-utils-for-either-a.patch|sonic-buildimage
 0011-arm64-kdump-support-add-support-in-kdump-config.patch|src/sonic-utilities
 0011-drivers-i2c-fix-after-kdump-hang.patch|src/sonic-linux-kernel


### PR DESCRIPTION
Why I did it
AC5P-RD (arm64-marvell_rd98DX45xx_cn9131-r0) may have disk scsi or mmcblk, but only scsi is handled.
On the "sonic-installer install" action the blk_dev is empty instead of "blk_dev=/dev/mmcblk0"
leading to wrong Uboot env parameters
  sonic_boot_load= ... mmc 0: ...
  sonic_boot_load_old= ... mmc 0: ...
instead of correct "mmc 0:2"
The further reboot fails with
  Wrong Image Format for bootm command
  ERROR: can't get kernel image!

How I did it
Add mmc_bus="mmc0:0001" and use in get_install_device() as last default.

How to test
sonic-installer install sonic-marvell-prestera-arm64.bin; reboot