### PR TITLE
[s-utilities] sonic_installer: add sync before migration

### DIFF
--- a/files/202505/0001-sonic_installer-add-sync-before-migration.patch
+++ b/files/202505/0001-sonic_installer-add-sync-before-migration.patch
@@ -1,0 +1,38 @@
+From c113b0d1d550b8c51cd31b1af5c29840bb9e325f Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Sun, 22 Jun 2025 18:09:40 +0300
+Subject: [PATCH 1/1] sonic_installer: add sync before migration
+
+Add extra 'sync' command to the sonic_installer to eliminate
+timeout failure in the following command
+ chroot /tmp/image-fs sonic-package-manager \
+   migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock
+on a slow or removable disk (for example - on Intel-Falcon board).
+
+This sync should be called before first chroot.
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ sonic_installer/main.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/sonic_installer/main.py b/sonic_installer/main.py
+index 6a445504..4cc48725 100644
+--- a/sonic_installer/main.py
++++ b/sonic_installer/main.py
+@@ -358,6 +358,12 @@ def migrate_sonic_packages(bootloader, binary_image_version):
+             run_command_or_raise(["mkdir", "-p", new_image_work_dir])
+             mount_overlay_fs(new_image_mount, new_image_upper_dir, new_image_work_dir, new_image_mount)
+             mount_bind(new_image_docker_dir, new_image_docker_mount)
++
++            # sync to eliminate timeout on the
++            # chroot /tmp/image-fs SONIC_PACKAGE_MANAGER migrate /tmp/packages.json --dockerd-socket DOCKERD_SOCK
++            click.echo('Command sync ...   could take several seconds on slow or removable disk')
++            run_command(["sync"])
++
+             mount_procfs_chroot(new_image_mount)
+             mount_sysfs_chroot(new_image_mount)
+             # Assume if docker.sh script exists we are installing Application Extension compatible image.
+-- 
+2.25.1
+

--- a/files/202505/series_marvell-prestera_amd64
+++ b/files/202505/series_marvell-prestera_amd64
@@ -1,3 +1,4 @@
 0001-buildimage-print-each-build-target-on-separated-line.patch|sonic-buildimage
+0001-sonic_installer-add-sync-before-migration.patch|src/sonic-utilities
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage

--- a/files/master/0001-sonic_installer-add-sync-before-migration.patch
+++ b/files/master/0001-sonic_installer-add-sync-before-migration.patch
@@ -1,0 +1,38 @@
+From c113b0d1d550b8c51cd31b1af5c29840bb9e325f Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Sun, 22 Jun 2025 18:09:40 +0300
+Subject: [PATCH 1/1] sonic_installer: add sync before migration
+
+Add extra 'sync' command to the sonic_installer to eliminate
+timeout failure in the following command
+ chroot /tmp/image-fs sonic-package-manager \
+   migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock
+on a slow or removable disk (for example - on Intel-Falcon board).
+
+This sync should be called before first chroot.
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ sonic_installer/main.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/sonic_installer/main.py b/sonic_installer/main.py
+index 6a445504..4cc48725 100644
+--- a/sonic_installer/main.py
++++ b/sonic_installer/main.py
+@@ -358,6 +358,12 @@ def migrate_sonic_packages(bootloader, binary_image_version):
+             run_command_or_raise(["mkdir", "-p", new_image_work_dir])
+             mount_overlay_fs(new_image_mount, new_image_upper_dir, new_image_work_dir, new_image_mount)
+             mount_bind(new_image_docker_dir, new_image_docker_mount)
++
++            # sync to eliminate timeout on the
++            # chroot /tmp/image-fs SONIC_PACKAGE_MANAGER migrate /tmp/packages.json --dockerd-socket DOCKERD_SOCK
++            click.echo('Command sync ...   could take several seconds on slow or removable disk')
++            run_command(["sync"])
++
+             mount_procfs_chroot(new_image_mount)
+             mount_sysfs_chroot(new_image_mount)
+             # Assume if docker.sh script exists we are installing Application Extension compatible image.
+-- 
+2.25.1
+

--- a/files/master/series_marvell-prestera_amd64
+++ b/files/master/series_marvell-prestera_amd64
@@ -1,3 +1,4 @@
 0001-buildimage-print-each-build-target-on-separated-line.patch|sonic-buildimage
+0001-sonic_installer-add-sync-before-migration.patch|src/sonic-utilities
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage


### PR DESCRIPTION
Add extra 'sync' command to the sonic_installer to eliminate timeout failure in the following command
 chroot /tmp/image-fs sonic-package-manager \
   migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock
on a slow or removable disk (for example - on Intel-Falcon board).

This sync should be called before first chroot.