### PR TITLE
[utilities] restart mgmt over-usb interface if not RUNNING

### DIFF
--- a/files/202505/0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch
+++ b/files/202505/0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch
@@ -1,0 +1,81 @@
+From 5ab4c220bf604f78d517e5697e00a7b78354d753 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Tue, 8 Jul 2025 18:55:19 +0300
+Subject: [PATCH] [utilities] restart mgmt over-usb interface if not RUNNING
+
+PROBLEM:
+Sometimes after "config reload" command the management
+interface (eth0) connected over ETH-USB device is UP/RUNNING
+on a remote peer side, but stays not-running on the local side.
+This is well-known negotiation problem of ETH-over-USB devices.
+
+SOLUTION:
+If the management interface is a USB device and is not RUNNING
+(/sys/class/net/eth0/operstate is not "up") at the end of the
+"config reload" command
+bring it down and up with delay to trigger renegotiation.
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+
+diff --git a/config/main.py b/config/main.py
+index e3b2c44e..a2ba6eb5 100644
+--- a/config/main.py
++++ b/config/main.py
+@@ -1031,6 +1031,45 @@ def get_device_name():
+     except Exception as e:
+         return None
+ 
++def get_mgmt_interface():
++    """
++    Parse /etc/sonic/config_db.json to find the management interface name (e.g., eth0).
++    """
++    try:
++        with open('/etc/sonic/config_db.json') as f:
++            config = json.load(f)
++        mgmt_entries = config.get("MGMT_INTERFACE", {})
++        if not mgmt_entries:
++            return None
++        # Example key: "eth0|10.3.141.10/24"
++        return list(mgmt_entries.keys())[0].split('|')[0]
++    except Exception as e:
++        print(f"Failed to get mgmt interface from config_db.json: {e}")
++        return None
++
++def reset_mgmt_interface_if_usb_not_running():
++    """
++    If the management interface is a USB device and not RUNNING,
++    bring it down and up with delay to trigger renegotiation.
++    """
++    iface = get_mgmt_interface()
++    if not iface:
++        return
++    if 'usb' not in os.path.realpath(f"/sys/class/net/{iface}/device"):
++        return
++   try:
++        with open(f"/sys/class/net/{iface}/operstate") as f:
++            operstate = f.read().strip()
++        if operstate == "up":
++            return  # Already RUNNING
++    except Exception:
++        pass  # Continue to attempt reset
++
++    click.echo("Reset USB-based mgmt interface for re-negotiation")
++    subprocess.run(["ip", "link", "set", iface, "down"], check=True)
++    time.sleep(1.0)
++    subprocess.run(["ip", "link", "set", iface, "up"], check=True)
++
+ def _restart_services():
+     last_interface_config_timestamp = get_service_finish_timestamp('interfaces-config')
+     last_networking_timestamp = get_service_finish_timestamp('networking')
+@@ -1063,6 +1102,8 @@ def _restart_services():
+         clicommon.run_command(['sudo', 'systemctl', 'stop', 'syncd'])
+         clicommon.run_command(['sudo', 'systemctl', 'restart', 'swss'])
+ 
++    reset_mgmt_interface_if_usb_not_running()
++
+ def _per_namespace_swss_ready(service_name):
+     out, _ = clicommon.run_command(['systemctl', 'show', str(service_name), '--property', 'ActiveState', '--value'], return_cmd=True)
+     if out.strip() != "active":
+-- 
+2.25.1
+

--- a/files/202505/series_marvell-prestera_amd64
+++ b/files/202505/series_marvell-prestera_amd64
@@ -2,4 +2,6 @@
 0001-sonic_installer-add-sync-before-migration.patch|src/sonic-utilities
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
+0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage

--- a/files/202505/series_marvell-prestera_arm64
+++ b/files/202505/series_marvell-prestera_arm64
@@ -6,6 +6,8 @@
 20250-master-1-Add-Wistron-platform-ES1227-54TS-and-ES2227-54TS.patch|sonic-buildimage
 20250-master-2-Add-Wistron-platform-ES1227-54TS-and-ES2227-54TS.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
+0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0018-kdrivers-i2c-fix-after-kdump-crash.patch|src/sonic-linux-kernel
 0019-kdrivers-irqchip-irq-mvebu-gicp-clear-pending.patch|src/sonic-linux-kernel
 0020-arm64-kdump-support-add-support-in-kdump-config.patch|src/sonic-utilities

--- a/files/202505/series_marvell-prestera_armhf
+++ b/files/202505/series_marvell-prestera_armhf
@@ -2,4 +2,5 @@
 0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
 0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage

--- a/files/master/0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch
+++ b/files/master/0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch
@@ -1,0 +1,81 @@
+From 5ab4c220bf604f78d517e5697e00a7b78354d753 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Tue, 8 Jul 2025 18:55:19 +0300
+Subject: [PATCH] [utilities] restart mgmt over-usb interface if not RUNNING
+
+PROBLEM:
+Sometimes after "config reload" command the management
+interface (eth0) connected over ETH-USB device is UP/RUNNING
+on a remote peer side, but stays not-running on the local side.
+This is well-known negotiation problem of ETH-over-USB devices.
+
+SOLUTION:
+If the management interface is a USB device and is not RUNNING
+(/sys/class/net/eth0/operstate is not "up") at the end of the
+"config reload" command
+bring it down and up with delay to trigger renegotiation.
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+
+diff --git a/config/main.py b/config/main.py
+index e3b2c44e..a2ba6eb5 100644
+--- a/config/main.py
++++ b/config/main.py
+@@ -1031,6 +1031,45 @@ def get_device_name():
+     except Exception as e:
+         return None
+ 
++def get_mgmt_interface():
++    """
++    Parse /etc/sonic/config_db.json to find the management interface name (e.g., eth0).
++    """
++    try:
++        with open('/etc/sonic/config_db.json') as f:
++            config = json.load(f)
++        mgmt_entries = config.get("MGMT_INTERFACE", {})
++        if not mgmt_entries:
++            return None
++        # Example key: "eth0|10.3.141.10/24"
++        return list(mgmt_entries.keys())[0].split('|')[0]
++    except Exception as e:
++        print(f"Failed to get mgmt interface from config_db.json: {e}")
++        return None
++
++def reset_mgmt_interface_if_usb_not_running():
++    """
++    If the management interface is a USB device and not RUNNING,
++    bring it down and up with delay to trigger renegotiation.
++    """
++    iface = get_mgmt_interface()
++    if not iface:
++        return
++    if 'usb' not in os.path.realpath(f"/sys/class/net/{iface}/device"):
++        return
++   try:
++        with open(f"/sys/class/net/{iface}/operstate") as f:
++            operstate = f.read().strip()
++        if operstate == "up":
++            return  # Already RUNNING
++    except Exception:
++        pass  # Continue to attempt reset
++
++    click.echo("Reset USB-based mgmt interface for re-negotiation")
++    subprocess.run(["ip", "link", "set", iface, "down"], check=True)
++    time.sleep(1.0)
++    subprocess.run(["ip", "link", "set", iface, "up"], check=True)
++
+ def _restart_services():
+     last_interface_config_timestamp = get_service_finish_timestamp('interfaces-config')
+     last_networking_timestamp = get_service_finish_timestamp('networking')
+@@ -1063,6 +1102,8 @@ def _restart_services():
+         clicommon.run_command(['sudo', 'systemctl', 'stop', 'syncd'])
+         clicommon.run_command(['sudo', 'systemctl', 'restart', 'swss'])
+ 
++    reset_mgmt_interface_if_usb_not_running()
++
+ def _per_namespace_swss_ready(service_name):
+     out, _ = clicommon.run_command(['systemctl', 'show', str(service_name), '--property', 'ActiveState', '--value'], return_cmd=True)
+     if out.strip() != "active":
+-- 
+2.25.1
+

--- a/files/master/series_marvell-prestera_amd64
+++ b/files/master/series_marvell-prestera_amd64
@@ -2,4 +2,6 @@
 0001-sonic_installer-add-sync-before-migration.patch|src/sonic-utilities
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
+0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage

--- a/files/master/series_marvell-prestera_arm64
+++ b/files/master/series_marvell-prestera_arm64
@@ -6,6 +6,8 @@
 20250-master-1-Add-Wistron-platform-ES1227-54TS-and-ES2227-54TS.patch|sonic-buildimage
 20250-master-2-Add-Wistron-platform-ES1227-54TS-and-ES2227-54TS.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
+0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0018-kdrivers-i2c-fix-after-kdump-crash.patch|src/sonic-linux-kernel
 0019-kdrivers-irqchip-irq-mvebu-gicp-clear-pending.patch|src/sonic-linux-kernel
 0020-arm64-kdump-support-add-support-in-kdump-config.patch|src/sonic-utilities

--- a/files/master/series_marvell-prestera_armhf
+++ b/files/master/series_marvell-prestera_armhf
@@ -2,4 +2,5 @@
 0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage
 0001-buildimage-marvell-prestera-sai-version-1.16.1-1.patch|sonic-buildimage
 0011-utilities-Nokia7215-WA-no-SAI-start-on-config-reload.patch|src/sonic-utilities
+0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage


### PR DESCRIPTION
PROBLEM:
Sometimes after "config reload" command the management interface (eth0) connected over ETH-USB device is UP/RUNNING on a remote peer side, but stays not-running on the local side. This is well-known negotiation problem of ETH-over-USB devices.

SOLUTION:
If the management interface is a USB device and is not RUNNING (/sys/class/net/eth0/operstate is not "up") at the end of the "config reload" command
bring it down and up with delay to trigger renegotiation.