### PR TITLE
sonic_build_script: revert: unset SONIC_IMAGE_VERSION

### DIFF
--- a/build/sonic_build_script.sh
+++ b/build/sonic_build_script.sh
@@ -572,12 +572,12 @@ main()
         echo "export NOSTRETCH=1"  >> build_cmd.txt
         echo "export NOBUSTER=1"   >> build_cmd.txt
         echo "export NOBULLSEYE=1" >> build_cmd.txt
-        echo "export SONIC_IMAGE_VERSION=${SONIC_SOURCE_DIR}" >> build_cmd.txt
+        #echo "export SONIC_IMAGE_VERSION=${SONIC_SOURCE_DIR}" >> build_cmd.txt
         export NOJESSIE=1
         export NOSTRETCH=1
         export NOBUSTER=1
         export NOBULLSEYE=1
-        export SONIC_IMAGE_VERSION=${SONIC_SOURCE_DIR}
+        #export SONIC_IMAGE_VERSION=${SONIC_SOURCE_DIR}
     fi
     build_ws
     set +x


### PR DESCRIPTION
The modified SONIC_IMAGE_VERSION causes for

INTERNALERROR> RuntimeError: Failed to evaluate condition,
 raw_condition=build_version.split(‘.’)[1].isdigit() and
 int(build_version.split(‘.’)[1]) <= 33,
 condition_str=build_version.split(‘.’)[1].isdigit() and
 int(build_version.split(‘.’)[1]) <= 33

Revert the patch setting SONIC_IMAGE_VERSION