### PR TITLE
marvell-prestera sai-1.16.1-2 branch fix

### DIFF
--- a/files/202505/0001-buildimage-marvell-prestera-sai-version-1.16.1-2.patch
+++ b/files/202505/0001-buildimage-marvell-prestera-sai-version-1.16.1-2.patch
@@ -1,17 +1,22 @@
-From 9ca11153b3a4e82043f87ab80cb2fc564781fc54 Mon Sep 17 00:00:00 2001
+From bfc0ec529b2377bca3a6d06f0f2edf7f3ed560e8 Mon Sep 17 00:00:00 2001
 From: Yan Markman <ymarkman@marvell.com>
 Date: Thu, 5 Jun 2025 22:04:39 +0300
 Subject: [PATCH] [buildimage] marvell-prestera sai version 1.16.1-2
 
 Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ platform/marvell-prestera/sai.mk | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/platform/marvell-prestera/sai.mk b/platform/marvell-prestera/sai.mk
-index 2191d415e..0ecbda7f6 100644
+index 2191d415e..5cffee2a9 100644
 --- a/platform/marvell-prestera/sai.mk
 +++ b/platform/marvell-prestera/sai.mk
-@@ -2,11 +2,11 @@
+@@ -1,12 +1,12 @@
+ # Marvell SAI
  
- BRANCH = master
+-BRANCH = master
++BRANCH = 202505 #touch force to patch
  ifeq ($(CONFIGURED_ARCH),arm64)
 -MRVL_SAI_VERSION = 1.15.1-1
 +MRVL_SAI_VERSION = 1.16.1-2

--- a/files/master/0001-buildimage-marvell-prestera-sai-version-1.16.1-2.patch
+++ b/files/master/0001-buildimage-marvell-prestera-sai-version-1.16.1-2.patch
@@ -1,17 +1,22 @@
-From 9ca11153b3a4e82043f87ab80cb2fc564781fc54 Mon Sep 17 00:00:00 2001
+From bfc0ec529b2377bca3a6d06f0f2edf7f3ed560e8 Mon Sep 17 00:00:00 2001
 From: Yan Markman <ymarkman@marvell.com>
 Date: Thu, 5 Jun 2025 22:04:39 +0300
 Subject: [PATCH] [buildimage] marvell-prestera sai version 1.16.1-2
 
 Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ platform/marvell-prestera/sai.mk | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/platform/marvell-prestera/sai.mk b/platform/marvell-prestera/sai.mk
-index 2191d415e..0ecbda7f6 100644
+index 2191d415e..5cffee2a9 100644
 --- a/platform/marvell-prestera/sai.mk
 +++ b/platform/marvell-prestera/sai.mk
-@@ -2,11 +2,11 @@
+@@ -1,12 +1,12 @@
+ # Marvell SAI
  
- BRANCH = master
+-BRANCH = master
++BRANCH = master #touch force to patch
  ifeq ($(CONFIGURED_ARCH),arm64)
 -MRVL_SAI_VERSION = 1.15.1-1
 +MRVL_SAI_VERSION = 1.16.1-2


### PR DESCRIPTION
Fix "BRANCH = master" vs "BRANCH = 202505" configuration. This fix is not critical/important NOW, whilst the github.com/Marvell-switching/sonic-marvell-binaries/raw/master/ARCH/sai-plugin/master/ github.com/Marvell-switching/sonic-marvell-binaries/raw/master/ARCH/sai-plugin/202505/
    are in sync.
But will be important when master would be advanced and different vs the 202505.