### PR TITLE
FIX print-each-build-target-on-separated-line

### DIFF
--- a/files/202505/0001-buildimage-print-each-build-target-on-separated-line.patch
+++ b/files/202505/0001-buildimage-print-each-build-target-on-separated-line.patch
@@ -37,7 +37,7 @@ index af272843d..37da3a2df 100755
  count=1
  for i in $(cat ${target_list_file}); do
 -    printf "[ %02d ] [ %s ]\n" "${count}" "$i"
-+    if [ "${SONIC_BUILD_JOBS}" -eq 1 ]; then
++    if [[ -v SONIC_BUILD_JOBS && "${SONIC_BUILD_JOBS}" -eq 1 ]]; then
 +        printf "[ %02d ] [ %s ]\n\n" "${count}" "$i"
 +    else
 +        printf "[ %02d ] [ %s ]\n" "${count}" "$i"

--- a/files/master/0001-buildimage-print-each-build-target-on-separated-line.patch
+++ b/files/master/0001-buildimage-print-each-build-target-on-separated-line.patch
@@ -37,7 +37,7 @@ index af272843d..37da3a2df 100755
  count=1
  for i in $(cat ${target_list_file}); do
 -    printf "[ %02d ] [ %s ]\n" "${count}" "$i"
-+    if [ "${SONIC_BUILD_JOBS}" -eq 1 ]; then
++    if [[ -v SONIC_BUILD_JOBS && "${SONIC_BUILD_JOBS}" -eq 1 ]]; then
 +        printf "[ %02d ] [ %s ]\n\n" "${count}" "$i"
 +    else
 +        printf "[ %02d ] [ %s ]\n" "${count}" "$i"


### PR DESCRIPTION
FIX default azure case where the SONIC_BUILD_JOBS is not defined