### PR TITLE
Falcon12.8T-32x100G profile sfp chassis

### DIFF
--- a/files/master/0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch
+++ b/files/master/0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch
@@ -1,0 +1,51 @@
+From a409dc1c9842782bf6406f2486f8757e93f0f17c Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Sun, 5 Oct 2025 16:19:26 +0300
+Subject: [PATCH 1/1] Falcon-12.8T FALCON32x100G profile
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ db98cx8580-32cd/sonic_platform/chassis.py   | 1 +
+ db98cx8580-32cd/sonic_platform/sfp.py       | 1 +
+ db98cx8580-32cd/sonic_platform/sfp_event.py | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/db98cx8580-32cd/sonic_platform/chassis.py b/db98cx8580-32cd/sonic_platform/chassis.py
+index 76ae775..19fc06a 100644
+--- a/db98cx8580-32cd/sonic_platform/chassis.py
++++ b/db98cx8580-32cd/sonic_platform/chassis.py
+@@ -64,6 +64,7 @@ profile_48x25G_8x100G = {
+ sfputil_profiles = {
+  "FC12_8T-DB":profile_12_8_db,
+  "FC48x25G8x100GR4":profile_48x25G_8x100G,
++ "FALCON32x100G":profile_32x25G,
+  "FALCON32X25G":profile_32x25G
+ }
+ 
+diff --git a/db98cx8580-32cd/sonic_platform/sfp.py b/db98cx8580-32cd/sonic_platform/sfp.py
+index 3e699a0..fbd1eeb 100644
+--- a/db98cx8580-32cd/sonic_platform/sfp.py
++++ b/db98cx8580-32cd/sonic_platform/sfp.py
+@@ -64,6 +64,7 @@ profile_48x25G_8x100G = {
+ sfputil_profiles = {
+  "FC12_8T-DB":profile_12_8_db,
+  "FC48x25G8x100GR4":profile_48x25G_8x100G,
++ "FALCON32x100G":profile_32x25G,
+  "FALCON32X25G":profile_32x25G
+ }
+ 
+diff --git a/db98cx8580-32cd/sonic_platform/sfp_event.py b/db98cx8580-32cd/sonic_platform/sfp_event.py
+index f016a24..f030957 100644
+--- a/db98cx8580-32cd/sonic_platform/sfp_event.py
++++ b/db98cx8580-32cd/sonic_platform/sfp_event.py
+@@ -55,6 +55,7 @@ profile_48x25G_8x100G = {
+ sfputil_profiles = {
+  "FC12_8T-DB":profile_12_8_db,
+  "FC48x25G8x100GR4":profile_48x25G_8x100G,
++ "FALCON32x100G":profile_32x25G,
+  "FALCON32X25G":profile_32x25G
+ }
+ 
+-- 
+2.34.1
+

--- a/files/master/series_marvell-prestera_amd64
+++ b/files/master/series_marvell-prestera_amd64
@@ -3,3 +3,4 @@
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
+0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell


### PR DESCRIPTION
Falcon-12.8T (db98cx8580-32cd)
add profile FALCON32x100G (same as profile_32x25G)
into files
 platform/marvell-prestera/sonic-platform-marvell/db98cx8580-32cd/sonic_platform/chassis.py
 platform/marvell-prestera/sonic-platform-marvell/db98cx8580-32cd/sonic_platform/sfp.py
 platform/marvell-prestera/sonic-platform-marvell/db98cx8580-32cd/sonic_platform/sfp_event.py