### PR TITLE
mrvl-prestera: k6.12 mvcpss drivers

### DIFF
--- a/files/master/0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch
+++ b/files/master/0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch
@@ -1,0 +1,564 @@
+From c543f8396528e43d64dfa25361ab0a915284bc18 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Sat, 27 Sep 2025 15:33:47 +0300
+Subject: [PATCH 1/1] platform/marvell-prestera/mrvl-prestera: k6.12 mvcpss.ko
+ driver
+
+Fix/adjust armhf and generic linuxNoKernelModule/drivers
+for compilation with k6.12.
+
+The changes are fully backward compatible with previous k6.1
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ .../linuxNoKernelModule/drivers/dmaDriver.c     | 10 ++++++++++
+ .../linuxNoKernelModule/drivers/dmaDriver2.c    | 10 ++++++++++
+ .../linuxNoKernelModule/drivers/ethDriver.c     | 17 +++++++++++++++++
+ .../linuxNoKernelModule/drivers/ethOpsDriver.c  |  4 ++++
+ .../linuxNoKernelModule/drivers/intDriver.c     |  4 ++++
+ .../linuxNoKernelModule/drivers/mbusDriver.c    |  7 +++++++
+ .../drivers/mvDriverTemplate.h                  | 13 +++++++++----
+ .../linuxNoKernelModule/drivers/mvpci.c         |  3 +++
+ .../linuxNoKernelModule/drivers/saiMod.c        |  4 ++++
+ .../linuxNoKernelModule/drivers/dmaDriver.c     | 10 ++++++++++
+ .../linuxNoKernelModule/drivers/dmaDriver2.c    | 10 ++++++++++
+ .../linuxNoKernelModule/drivers/ethDriver.c     | 17 +++++++++++++++++
+ .../linuxNoKernelModule/drivers/ethOpsDriver.c  |  4 ++++
+ .../linuxNoKernelModule/drivers/intDriver.c     |  4 ++++
+ .../linuxNoKernelModule/drivers/mbusDriver.c    |  7 +++++++
+ .../drivers/mvDriverTemplate.h                  | 13 +++++++++----
+ .../linuxNoKernelModule/drivers/mvpci.c         |  3 +++
+ .../linuxNoKernelModule/drivers/saiMod.c        |  4 ++++
+ 18 files changed, 136 insertions(+), 8 deletions(-)
+ mode change 100755 => 100644 drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+ mode change 100755 => 100644 drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+index 89dc64e..df33765 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+@@ -208,6 +208,9 @@ disclaimer.
+ #define MV_DMA_ALLOC_FLAGS GFP_DMA32 | GFP_NOFS
+ #define MAX_DMA_ALLOC_RETRIES   10
+ 
++void mvdmadrv_exit(void);
++int mvdmadrv_init(void);
++
+ /* Character device context */
+ static struct mvchrdev_ctx *chrdrv_ctx;
+ /* Did we successfully registered as platform driver? zero means yes */
+@@ -1030,13 +1033,19 @@ static int mvdmadrv_pdriver_probe(struct platform_device *pdev)
+ 	return 0;
+ };
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
++static void mvdmadrv_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvdmadrv_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	BUG_ON(!platdrv_registered);
+ 
+ 	of_reserved_mem_device_release(&pdev->dev);
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvdmadrv_of_match_ids[] = {
+@@ -1083,6 +1092,7 @@ void mvdmadrv_exit(void)
+ 		kfree(shared_dmaBlock);
+ 	}
+ }
++
+ int mvdmadrv_init(void)
+ {
+ #ifdef SUPPORT_PLATFORM_DEVICE
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+index c933825..812d36c 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+@@ -163,6 +163,9 @@ struct list_head opened_files; /* List of file_desc (for debugfs) */
+ /* debugfs dir and mmaps file */
+ struct dentry *debugfs_dir, *debugfs_mmaps;
+ 
++void mvdma2_exit(void);
++int mvdma2_init(void);
++
+ /* Add filep to opened_files */
+ static void mvdma_add_open_file(struct file *file)
+ {
+@@ -693,13 +696,20 @@ static int mvdma_pdriver_probe(struct platform_device *pdev)
+ 	return 0;
+ };
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
++static void mvdma_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvdma_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	BUG_ON(!platform_dev_mappings);
+ #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,19,8))
+ 	of_reserved_mem_device_release(&pdev->dev);
+ #endif
++
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvdma_of_match_ids[] = {
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+old mode 100755
+new mode 100644
+index 85b7766..5666ed5
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+@@ -409,6 +409,13 @@ struct device_private_data falcon_private_data = {REG_ADDR_BASE_FALCON};
+ struct device_private_data ac5p_private_data = {REG_ADDR_BASE_AC5P};
+ struct device_private_data ac5x_private_data = {REG_ADDR_BASE_AC5X};
+ 
++int mvppnd_poll(struct napi_struct *napi, int budget);
++void mvppnd_free_wq(struct mvppnd_dev *ppdev);
++int mvppnd_open(struct net_device *dev);
++int mvppnd_stop(struct net_device *dev);
++int mvppnd_init(void);
++void mvppnd_exit(void);
++
+ /* 
+  * netif_receive_skb_list() was only introduced in
+  * kernel 4.19 . Make a naive implementation of
+@@ -4065,7 +4072,11 @@ out:
+ 	return 0;
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
++static void mvppnd_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvppnd_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	struct mvppnd_dev *ppdev;
+ 
+@@ -4073,7 +4084,11 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
+ 
+ 	ppdev = (struct mvppnd_dev *)dev_get_drvdata(&pdev->dev);
+ 	if (!ppdev)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+ 		return 0;
++#else
++		return;
++#endif
+ 
+ 	ppdev->going_down = true;
+ 
+@@ -4088,7 +4103,9 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
+ 
+ 	dev_info(&pdev->dev, "Detached from device\n");
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvppnd_of_match_ids[] = {
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+index bf25339..1d5b4e5 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+@@ -160,6 +160,10 @@ MODULE_PARM_DESC(rx_counter_dump, "Counter, when exceeds print message");
+ 
+ struct rx_context rx_ctx = {};
+ 
++int process_rx(struct net_device *ndev, unsigned char *data, int *sz,
++		int max_sz);
++int process_tx(struct net_device *ndev, struct sk_buff *skb);
++
+ /**
+ * @internal print_buf function
+ * @endinternal
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+index 8952181..1d2a11d 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+@@ -60,6 +60,10 @@ disclaimer.
+ #include <linux/list.h>
+ #include <linux/delay.h>
+ 
++void mvPresteraBh(unsigned long data);
++void mvintdrv_exit(void);
++int mvintdrv_init(void);
++
+ /* Character device context */
+ static struct mvchrdev_ctx *chrdrv_ctx;
+ static struct semaphore mvint_pci_devs_sem;
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+index 19025db..c498f5d 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+@@ -66,6 +66,9 @@ static struct mvchrdev_ctx *chrdrv_ctx;
+ 
+ int mvMbusDrvDevId = 0;
+ 
++void mvmbusdrv_exit(void);
++int mvmbusdrv_init(void);
++
+ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
+ {
+ 	struct mv_resource_info res = {0};
+@@ -91,7 +94,11 @@ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
+ 		return -ENXIO;
+ 	}
+ 	/* VM_IO for I/O memory */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,0)
+ 	vma->vm_flags |= VM_IO;
++#else
++	vm_flags_set(vma, VM_IO);
++#endif
+ 	/* disable caching on mapped memory */
+ 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+ 	vma->vm_pgoff = res.start >> PAGE_SHIFT;
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
+index 13424e0..31d4b64 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
+@@ -51,16 +51,18 @@ struct mvchrdev_ctx {
+ 	int minor;
+ };
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,69)
++# if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+ static char *mvchrdev_devnode(struct device *dev, umode_t *mode)
++# else
++static char *mvchrdev_devnode(const struct device *dev, umode_t *mode)
++# endif
+ #else /* < 3.4.69 */
+ static char *mvchrdev_devnode(struct device *dev, mode_t *mode)
+ #endif /* < 3.4.69 */
+ {
+ 	return kasprintf(GFP_KERNEL, "%s", dev->kobj.name);
+ }
+-#endif /* >= 2.6.32 */
+ 
+ static void mvchrdev_cleanup(struct mvchrdev_ctx *ctx)
+ {
+@@ -107,15 +109,18 @@ static struct mvchrdev_ctx *mvchrdev_init(const char *name,
+ 		goto err_unreg_drv;
+ 	}
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+ 	ctx->class = class_create(THIS_MODULE, name);
++#else
++	ctx->class = class_create(name);
++#endif
+ 	if (IS_ERR(ctx->class)) {
+ 		pr_err("%s: Fail to create class (%d)\n", name, rc);
+ 		goto err_del_cdev;
+ 	}
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
+ 	ctx->class->devnode = mvchrdev_devnode;
+-#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)
+ 	ctx->dev = device_create(ctx->class, NULL, dev, NULL, name);
+ #else
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+index 5eeedc2..66b0043 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+@@ -45,6 +45,9 @@
+ 
+ #include <linux/pci.h>
+ 
++void mvpci_exit(void);
++int mvpci_init(void);
++
+ static int mvpcidrv_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ {
+ 	int rc;
+diff --git a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+index 17f3cd0..6224df0 100644
+--- a/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
++++ b/drivers/armhf/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+@@ -605,7 +605,11 @@ static int __init sai_init(void)
+ 
+     major = err;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+     sai_class = class_create(THIS_MODULE, SAI_NAME);
++#else
++    sai_class = class_create(SAI_NAME);
++#endif
+     if (IS_ERR(sai_class)) {
+         err = PTR_ERR(sai_class);
+         goto out_chrdev;
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+index dac1622..1dc38ee 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver.c
+@@ -116,6 +116,9 @@ disclaimer.
+ 
+ #define MV_DMA_ALLOC_FLAGS GFP_DMA32 | GFP_NOFS
+ 
++void mvdmadrv_exit(void);
++int mvdmadrv_init(void);
++
+ /* Character device context */
+ static struct mvchrdev_ctx *chrdrv_ctx;
+ /* Did we successfully registered as platform driver? zero means yes */
+@@ -446,13 +449,19 @@ static int mvdmadrv_pdriver_probe(struct platform_device *pdev)
+ 	return 0;
+ };
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
++static void mvdmadrv_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvdmadrv_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	BUG_ON(!platdrv_registered);
+ 
+ 	of_reserved_mem_device_release(&pdev->dev);
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvdmadrv_of_match_ids[] = {
+@@ -492,6 +501,7 @@ void mvdmadrv_exit(void)
+ 		kfree(shared_dmaBlock);
+ 	}
+ }
++
+ int mvdmadrv_init(void)
+ {
+ #ifdef SUPPORT_PLATFORM_DEVICE
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+index 278fec0..5f538fe 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/dmaDriver2.c
+@@ -164,6 +164,9 @@ struct list_head opened_files; /* List of file_desc (for debugfs) */
+ /* debugfs dir and mmaps file */
+ struct dentry *debugfs_dir, *debugfs_mmaps;
+ 
++void mvdma2_exit(void);
++int mvdma2_init(void);
++
+ /* Add filep to opened_files */
+ static void mvdma_add_open_file(struct file *file)
+ {
+@@ -777,13 +780,20 @@ static int mvdma_pdriver_probe(struct platform_device *pdev)
+ 	return 0;
+ };
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
++static void mvdma_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvdma_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	BUG_ON(!platform_dev_mappings);
+ #if (LINUX_VERSION_CODE > KERNEL_VERSION(3,19,8))
+ 	of_reserved_mem_device_release(&pdev->dev);
+ #endif
++
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvdma_of_match_ids[] = {
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+old mode 100755
+new mode 100644
+index 012eddc..1204db1
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethDriver.c
+@@ -416,6 +416,13 @@ struct device_private_data ac5p_private_data = {REG_ADDR_BASE_AC5P};
+ struct device_private_data ac5x_private_data = {REG_ADDR_BASE_AC5X};
+ struct device_private_data ac5_private_data = {REG_ADDR_BASE_AC5};
+ 
++int mvppnd_poll(struct napi_struct *napi, int budget);
++void mvppnd_free_wq(struct mvppnd_dev *ppdev);
++int mvppnd_open(struct net_device *dev);
++int mvppnd_stop(struct net_device *dev);
++int mvppnd_init(void);
++void mvppnd_exit(void);
++
+ /*
+  * netif_receive_skb_list() was only introduced in
+  * kernel 4.19 . Make a naive implementation of
+@@ -4229,7 +4236,11 @@ out:
+ 	return 0;
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
++static void mvppnd_pdriver_remove(struct platform_device *pdev)
++#else
+ static int mvppnd_pdriver_remove(struct platform_device *pdev)
++#endif
+ {
+ 	struct mvppnd_dev *ppdev;
+ 
+@@ -4237,7 +4248,11 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
+ 
+ 	ppdev = (struct mvppnd_dev *)dev_get_drvdata(&pdev->dev);
+ 	if (!ppdev)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+ 		return 0;
++#else
++		return;
++#endif
+ 
+ 	ppdev->going_down = true;
+ 
+@@ -4252,7 +4267,9 @@ static int mvppnd_pdriver_remove(struct platform_device *pdev)
+ 
+ 	dev_info(&pdev->dev, "Detached from device\n");
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+ 	return 0;
++#endif
+ }
+ 
+ static const struct of_device_id mvppnd_of_match_ids[] = {
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+index bf25339..1d5b4e5 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/ethOpsDriver.c
+@@ -160,6 +160,10 @@ MODULE_PARM_DESC(rx_counter_dump, "Counter, when exceeds print message");
+ 
+ struct rx_context rx_ctx = {};
+ 
++int process_rx(struct net_device *ndev, unsigned char *data, int *sz,
++		int max_sz);
++int process_tx(struct net_device *ndev, struct sk_buff *skb);
++
+ /**
+ * @internal print_buf function
+ * @endinternal
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+index 553a21a..c274006 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/intDriver.c
+@@ -58,6 +58,10 @@ disclaimer.
+ #include <linux/irq.h>
+ #include <linux/list.h>
+ 
++void mvPresteraBh(unsigned long data);
++void mvintdrv_exit(void);
++int mvintdrv_init(void);
++
+ /* Character device context */
+ static struct mvchrdev_ctx *chrdrv_ctx;
+ 
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+index 19025db..c498f5d 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mbusDriver.c
+@@ -66,6 +66,9 @@ static struct mvchrdev_ctx *chrdrv_ctx;
+ 
+ int mvMbusDrvDevId = 0;
+ 
++void mvmbusdrv_exit(void);
++int mvmbusdrv_init(void);
++
+ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
+ {
+ 	struct mv_resource_info res = {0};
+@@ -91,7 +94,11 @@ static int mvMbusDrv_mmap(struct file * file, struct vm_area_struct *vma)
+ 		return -ENXIO;
+ 	}
+ 	/* VM_IO for I/O memory */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,0)
+ 	vma->vm_flags |= VM_IO;
++#else
++	vm_flags_set(vma, VM_IO);
++#endif
+ 	/* disable caching on mapped memory */
+ 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
+ 	vma->vm_pgoff = res.start >> PAGE_SHIFT;
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
+index 13424e0..31d4b64 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvDriverTemplate.h
+@@ -51,16 +51,18 @@ struct mvchrdev_ctx {
+ 	int minor;
+ };
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,69)
++# if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+ static char *mvchrdev_devnode(struct device *dev, umode_t *mode)
++# else
++static char *mvchrdev_devnode(const struct device *dev, umode_t *mode)
++# endif
+ #else /* < 3.4.69 */
+ static char *mvchrdev_devnode(struct device *dev, mode_t *mode)
+ #endif /* < 3.4.69 */
+ {
+ 	return kasprintf(GFP_KERNEL, "%s", dev->kobj.name);
+ }
+-#endif /* >= 2.6.32 */
+ 
+ static void mvchrdev_cleanup(struct mvchrdev_ctx *ctx)
+ {
+@@ -107,15 +109,18 @@ static struct mvchrdev_ctx *mvchrdev_init(const char *name,
+ 		goto err_unreg_drv;
+ 	}
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+ 	ctx->class = class_create(THIS_MODULE, name);
++#else
++	ctx->class = class_create(name);
++#endif
+ 	if (IS_ERR(ctx->class)) {
+ 		pr_err("%s: Fail to create class (%d)\n", name, rc);
+ 		goto err_del_cdev;
+ 	}
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
+ 	ctx->class->devnode = mvchrdev_devnode;
+-#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27)
+ 	ctx->dev = device_create(ctx->class, NULL, dev, NULL, name);
+ #else
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+index 5eeedc2..66b0043 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/mvpci.c
+@@ -45,6 +45,9 @@
+ 
+ #include <linux/pci.h>
+ 
++void mvpci_exit(void);
++int mvpci_init(void);
++
+ static int mvpcidrv_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ {
+ 	int rc;
+diff --git a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+index cf662f9..5da1f7c 100644
+--- a/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
++++ b/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers/saiMod.c
+@@ -657,7 +657,11 @@ static int __init sai_init(void)
+ 
+     major = err;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
+     sai_class = class_create(THIS_MODULE, SAI_NAME);
++#else
++    sai_class = class_create(SAI_NAME);
++#endif
+     if (IS_ERR(sai_class)) {
+         err = PTR_ERR(sai_class);
+         goto out_chrdev;
+-- 
+2.34.1
+

--- a/files/master/series_marvell-prestera_amd64
+++ b/files/master/series_marvell-prestera_amd64
@@ -4,3 +4,4 @@
 0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
 0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell
+0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera

--- a/files/master/series_marvell-prestera_arm64
+++ b/files/master/series_marvell-prestera_arm64
@@ -9,3 +9,4 @@
 0020-arm64-kdump-support-add-support-in-kdump-config.patch|src/sonic-utilities
 0021-arm64-kdump-support-Install-kdump-utils-for-either-a.patch|sonic-buildimage
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
+0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera

--- a/files/master/series_marvell-prestera_armhf
+++ b/files/master/series_marvell-prestera_armhf
@@ -2,3 +2,4 @@
 0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage
 0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
+0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera


### PR DESCRIPTION
Avoid CPSS drivers (mvcpss.ko) code-warnings for compilation under
linux-kernel 6.12.41which is used on TRIXIE.
