### PR TITLE
prestera trixie: debian/rules

### DIFF
--- a/files/master/0052-platform-marvell-prestera-sonic-platform-nokia-rules7215.patch
+++ b/files/master/0052-platform-marvell-prestera-sonic-platform-nokia-rules7215.patch
@@ -1,0 +1,178 @@
+From b71b2ab046397f0e5f1d7da409ce28314d581a1a Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Sat, 27 Sep 2025 20:17:36 +0300
+Subject: [PATCH 1/1] platform/marvell-prestera/sonic-platform-nokia: rules and
+ 7215
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ .../modules/cn9130_cpu_thermal_sensor.c       |  6 +-
+ .../7215-a1/modules/nokia_7215_ixs_a1_cpld.c  |  5 ++
+ .../sonic-platform-nokia/debian/rules         | 74 +++++++++----------
+ 3 files changed, 45 insertions(+), 40 deletions(-)
+
+diff --git a/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/cn9130_cpu_thermal_sensor.c b/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/cn9130_cpu_thermal_sensor.c
+index e11e28157..cbc2fe486 100644
+--- a/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/cn9130_cpu_thermal_sensor.c
++++ b/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/cn9130_cpu_thermal_sensor.c
+@@ -57,7 +57,8 @@ static long cn9130_thermal_read_reg_in_mcelcius(struct device *dev, struct cn913
+ 
+     //Read thermal value
+     status_regval = readl(temp_base+CN9130_TSEN_REG_STATUS_OFFSET);
+-    dev_dbg(dev, "%s: cn9130_thermal_read_reg_in_mcelcius: addr: 0x%lx value:0x%x\n", dev_name(data->hwmon_dev), temp_base+CN9130_TSEN_REG_STATUS_OFFSET, status_regval);
++    dev_dbg(dev, "%s: cn9130_thermal_read_reg_in_mcelcius: addr: %p value:0x%x\n",
++	    dev_name(data->hwmon_dev), (void*)(temp_base+CN9130_TSEN_REG_STATUS_OFFSET), status_regval);
+ 
+     //START MEASUREMENT
+     regval = readl(temp_base+CN9130_TSEN_REG_CTRL_0_OFFSET);
+@@ -224,7 +225,8 @@ static int __init cn9130_thermal_init_driver(void)
+     regval |= 1 << 0; //TSEN_START
+     writel(regval, thermal_data->temp_base+CN9130_TSEN_REG_CTRL_0_OFFSET);
+ 
+-    dev_info(dev, "%s: initialized. base_addr: 0x%lx virt_addr:0x%lx\n", dev_name(thermal_data->hwmon_dev), thermal_base_addr, thermal_data->temp_base);
++    dev_info(dev, "%s: initialized. base_addr: 0x%lx virt_addr:%p\n",
++	     dev_name(thermal_data->hwmon_dev), thermal_base_addr, (void *)thermal_data->temp_base);
+ 
+     return 0;
+ }
+diff --git a/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/nokia_7215_ixs_a1_cpld.c b/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/nokia_7215_ixs_a1_cpld.c
+index e90715dc3..828cfeff7 100644
+--- a/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/nokia_7215_ixs_a1_cpld.c
++++ b/platform/marvell-prestera/sonic-platform-nokia/7215-a1/modules/nokia_7215_ixs_a1_cpld.c
+@@ -42,6 +42,7 @@
+ #include <linux/of_device.h>
+ #include <linux/of.h>
+ #include <linux/mutex.h>
++#include <linux/version.h>
+ 
+ #define DRIVER_NAME "nokia_7215_a1_cpld"
+ 
+@@ -521,8 +522,12 @@ static const struct attribute_group nokia_7215_ixs_a1_cpld_group = {
+ };
+ 
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0))
++static int nokia_7215_ixs_a1_cpld_probe(struct i2c_client *client)
++#else
+ static int nokia_7215_ixs_a1_cpld_probe(struct i2c_client *client,
+         const struct i2c_device_id *dev_id)
++#endif
+ {
+     int status;
+      struct cpld_data *data=NULL;
+diff --git a/platform/marvell-prestera/sonic-platform-nokia/debian/rules b/platform/marvell-prestera/sonic-platform-nokia/debian/rules
+index f3fe01d1b..7dde1c706 100755
+--- a/platform/marvell-prestera/sonic-platform-nokia/debian/rules
++++ b/platform/marvell-prestera/sonic-platform-nokia/debian/rules
+@@ -22,25 +22,35 @@ PRESTERA_MODULE_PREFIX_ARMHF := mrvl-prestera/drivers/armhf/
+ PRESTERA_MODULE_SRC := /cpssEnabler/linuxNoKernelModule/drivers/
+ SERVICE_DIR := service
+ PLATFORM_DIR := sonic_platform
++#CONF_DIR := conf   - not used
++#UDEV_DIR := udev   - not used
+ 
+ %:
+-	dh $@ --with systemd,python3 --buildsystem=pybuild
++	dh $@ --with python3 --buildsystem=pybuild
+ 
+-clean:
+-	dh_testdir
+-	dh_testroot
+-	dh_clean
++override_dh_auto_clean:
+ 	(for mod in $(MODULE_DIRS); do \
++		$(MAKE) clean -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --clean -d $${mod}; \
++		fi; \
+ 		cd $(MOD_SRC_DIR)/$${mod}; \
+-		rm -rf build/; \
+ 		rm -rf $(MRVL_MODULE_DIR)/; \
+ 		rm -rf *.egg-info/; \
+ 		rm -f *.whl; \
+ 		cd $(MOD_SRC_DIR)/; \
+ 	done)
++	dh_clean
+ 
+-build:
++override_dh_auto_configure:
+ 	(for mod in $(MODULE_DIRS); do \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --configure -d $${mod}; \
++		fi; \
++	done)
++
++override_dh_auto_build:
++	(set -e; for mod in $(MODULE_DIRS); do \
+ 		mkdir -p $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR); \
+ 		if [ $$mod = "7215-a1" ] && [ $(CONFIGURED_ARCH) = "arm64" ]; then \
+ 			cp -r $(MOD_SRC_DIR)/../$(PRESTERA_MODULE_PREFIX)/* $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR)/; \
+@@ -61,46 +71,34 @@ build:
+ 		cd $(MOD_SRC_DIR); \
+ 	done)
+ 
+-binary: binary-arch binary-indep
+-	# Nothing to do
++override_dh_auto_test:
++	# No tests to run
+ 
+-binary-arch:
+-	# Nothing to do
++override_dh_usrlocal:
++	# debian/sonic-platform-<>-<>/usr/local/bin/* are already done
+ 
+-binary-indep:
+-	dh_testdir
+-	dh_installdirs
+-
+-	# Custom package commands
+-	(for mod in $(MODULE_DIRS); do \
++override_dh_auto_install:
++	(set -e; for mod in $(MODULE_DIRS); do \
++		doModInstall=false; \
++		if [ $$mod = "7215-a1" ] && [ $(CONFIGURED_ARCH) = "arm64" ]; then \
++			doModInstall=true; \
++		elif [ $$mod = "7215" ] && [ $(CONFIGURED_ARCH) = "armhf" ]; then \
++			doModInstall=true; \
++		fi; \
++		if [ "$$doModInstall" = false ]; then continue; fi; \
+ 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} /$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
+ 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} /usr/local/bin; \
+ 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} /boot; \
+ 		dh_installdirs -p$(PACKAGE_PRE_NAME)-$${mod} /lib/systemd/system; \
+ 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/$(PACKAGE_PRE_NAME)-$${mod}/lib/systemd/system/; \
+-		cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
++		if [ -d $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR) ]; then \
++			cp $(MOD_SRC_DIR)/$${mod}/$(UTILS_DIR)/* debian/$(PACKAGE_PRE_NAME)-$${mod}/usr/local/bin/; \
++		fi; \
+ 		cp $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR)/$(PRESTERA_MODULE_SRC)/mvcpss.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
+-		cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
++		if [ -d "$(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)" ] && ls "$(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)"/*.ko >/dev/null 2>&1; then \
++			cp $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/*.ko debian/$(PACKAGE_PRE_NAME)-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR); \
++		fi; \
+ 		cd $(MOD_SRC_DIR)/$${mod}; \
+ 		python3 setup.py install --root=$(MOD_SRC_DIR)/debian/$(PACKAGE_PRE_NAME)-$${mod} --install-layout=deb; \
+ 		cd $(MOD_SRC_DIR); \
+ 	done)
+-
+-	# Resuming debhelper scripts
+-	dh_testroot
+-	dh_install
+-	dh_installchangelogs
+-	dh_installdocs
+-	dh_systemd_enable
+-	dh_installinit
+-	dh_systemd_start
+-	dh_link
+-	dh_fixperms
+-	dh_compress
+-	dh_strip
+-	dh_installdeb
+-	dh_gencontrol
+-	dh_md5sums
+-	dh_builddeb
+-
+-.PHONY: build binary binary-arch binary-indep clean
+-- 
+2.34.1
+

--- a/files/master/0054-sonic-platform-marvell-rules-rd98dx45xx-rm.patch
+++ b/files/master/0054-sonic-platform-marvell-rules-rd98dx45xx-rm.patch
@@ -1,0 +1,44 @@
+From d9d3662c61e15eb2c3fc85abfaf7ab93632bbd40 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Mon, 6 Oct 2025 00:06:15 +0300
+Subject: [PATCH 1/1] sonic-platform-marvell rules rd98dx45xx rm
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ debian/rules | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/debian/rules b/debian/rules
+index 3450dd4..21a5bbc 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -12,7 +12,7 @@ endif
+ KERNEL_SRC :=  /lib/modules/$(KVERSION)
+ INSTALL_MOD_DIR := kernel/extra/
+ MOD_SRC_DIR:= $(shell pwd)
+-MODULE_DIRS:= rd98dx35xx_cn9131 rd98dx35xx rd98dx35xx-x86 db98cx8580-32cd db98cx8514-10cc db98cx8540-16cd db98cx8522-10cc rd98dx45xx_cn9131
++MODULE_DIRS:= rd98dx35xx_cn9131 rd98dx35xx rd98dx35xx-x86 db98cx8580-32cd db98cx8514-10cc db98cx8540-16cd db98cx8522-10cc
+ UTILS_DIR := utils
+ SERVICE_DIR := service
+ MRVL_MODULE_DIR:= mrvl-modules
+@@ -43,8 +43,6 @@ build:
+ 		make clean; \
+ 		if [ $$mod = "rd98dx35xx_cn9131" ]; then \
+ 			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y || exit 1; \
+-		elif [ $$mod = "rd98dx45xx_cn9131" ]; then \
+-			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y || exit 1; \
+         elif [ $$mod = "rd98dx35xx-x86" ];then \
+ 			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y CONFIG_KM_MVDMA2=y|| exit 1; \
+ 		elif [ $$mod = "rd98dx35xx" ]; then \
+@@ -79,8 +77,6 @@ binary-indep:
+ 	(for mod in $(MODULE_DIRS); do \
+ 		if [ $$mod = "rd98dx35xx_cn9131" ]; then \
+ 			pkg="rd98dx35xx-cn9131"; \
+-		elif [ $$mod = "rd98dx45xx_cn9131" ]; then \
+-			pkg="rd98dx45xx-cn9131"; \
+ 		else \
+ 			pkg=$$mod; \
+ 		fi; \
+-- 
+2.34.1
+

--- a/files/master/0055-sonic-platform-marvell-rules-for-trixie.patch
+++ b/files/master/0055-sonic-platform-marvell-rules-for-trixie.patch
@@ -1,0 +1,105 @@
+From 033b571d1ee4091ccfc3ccbb43608dd01af98738 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Mon, 29 Sep 2025 14:26:28 +0300
+Subject: [PATCH 1/2] sonic-platform-marvell: rules for trixie
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ debian/rules | 59 ++++++++++++++++++++--------------------------------
+ 1 file changed, 22 insertions(+), 37 deletions(-)
+
+diff --git a/debian/rules b/debian/rules
+index 21a5bbc..a109709 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -20,23 +20,31 @@ PRESTERA_MODULE_PREFIX := mrvl-prestera/drivers/generic/
+ PRESTERA_MODULE_SRC := cpssEnabler/linuxNoKernelModule/drivers/
+ 
+ %:
+-	dh $@ --with systemd,python3 --buildsystem=pybuild
++	dh $@ --with python3 --buildsystem=pybuild
+ 
+-clean:
+-	dh_testdir
+-	dh_testroot
+-	dh_clean
++override_dh_auto_clean:
+ 	(for mod in $(MODULE_DIRS); do \
++		$(MAKE) clean -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --clean -d $${mod}; \
++		fi; \
+ 		cd $(MOD_SRC_DIR)/$${mod}; \
+-		rm -rf build/; \
+-		rm -rf mrvl-modules/; \
++		rm -rf $(MRVL_MODULE_DIR)/; \
+ 		rm -rf *.egg-info/; \
+ 		rm -f *.whl; \
+ 		cd $(MOD_SRC_DIR)/; \
+ 	done)
++	dh_clean
+ 
+-build:
++override_dh_auto_configure:
+ 	(for mod in $(MODULE_DIRS); do \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --configure -d $${mod}; \
++		fi; \
++	done)
++
++override_dh_auto_build:
++	(set -e; for mod in $(MODULE_DIRS); do \
+ 		mkdir -p $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR); \
+ 		cp -r $(MOD_SRC_DIR)/../$(PRESTERA_MODULE_PREFIX)/* $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR)/; \
+ 		cd $(MOD_SRC_DIR)/$${mod}/$(MRVL_MODULE_DIR)/$(PRESTERA_MODULE_SRC); \
+@@ -63,18 +71,14 @@ build:
+ 	done)
+ 
+ 
+-binary: binary-arch binary-indep
+-	# Nothing to do
+-
+-binary-arch:
+-	# Nothing to do
++override_dh_auto_test:
++	# No tests to run
+ 
+-binary-indep:
+-	dh_testdir
+-	dh_installdirs
++override_dh_usrlocal:
++	# debian/sonic-platform-<>-<>/usr/local/bin/* are already done
+ 
+-	# Custom package commands
+-	(for mod in $(MODULE_DIRS); do \
++override_dh_auto_install:
++	(set -e; for mod in $(MODULE_DIRS); do \
+ 		if [ $$mod = "rd98dx35xx_cn9131" ]; then \
+ 			pkg="rd98dx35xx-cn9131"; \
+ 		else \
+@@ -94,22 +98,3 @@ binary-indep:
+ 		python3 setup.py install --root=$(MOD_SRC_DIR)/debian/sonic-platform-$${pkg} --install-layout=deb; \
+ 		cd $(MOD_SRC_DIR); \
+ 	done)
+-
+-	# Resuming debhelper scripts
+-	dh_testroot
+-	dh_install
+-	dh_installchangelogs
+-	dh_installdocs
+-	dh_systemd_enable
+-	dh_installinit
+-	dh_systemd_start
+-	dh_link
+-	dh_fixperms
+-	dh_compress
+-	dh_strip
+-	dh_installdeb
+-	dh_gencontrol
+-	dh_md5sums
+-	dh_builddeb
+-
+-.PHONY: build binary binary-arch binary-indep clean
+-- 
+2.34.1
+

--- a/files/master/0056-sonic-platform-marvell-rules-rd98dx45xx-add.patch
+++ b/files/master/0056-sonic-platform-marvell-rules-rd98dx45xx-add.patch
@@ -1,0 +1,44 @@
+From 1383b56b74bf7cb9e847f771e77e9c1e7e03ef5c Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Mon, 6 Oct 2025 00:22:21 +0300
+Subject: [PATCH 1/1] sonic-platform-marvell rules rd98dx45xx add
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ debian/rules | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/debian/rules b/debian/rules
+index a109709..fcf4dee 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -12,7 +12,7 @@ endif
+ KERNEL_SRC :=  /lib/modules/$(KVERSION)
+ INSTALL_MOD_DIR := kernel/extra/
+ MOD_SRC_DIR:= $(shell pwd)
+-MODULE_DIRS:= rd98dx35xx_cn9131 rd98dx35xx rd98dx35xx-x86 db98cx8580-32cd db98cx8514-10cc db98cx8540-16cd db98cx8522-10cc
++MODULE_DIRS:= rd98dx35xx_cn9131 rd98dx35xx rd98dx35xx-x86 db98cx8580-32cd db98cx8514-10cc db98cx8540-16cd db98cx8522-10cc rd98dx45xx_cn9131
+ UTILS_DIR := utils
+ SERVICE_DIR := service
+ MRVL_MODULE_DIR:= mrvl-modules
+@@ -51,6 +51,8 @@ override_dh_auto_build:
+ 		make clean; \
+ 		if [ $$mod = "rd98dx35xx_cn9131" ]; then \
+ 			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y || exit 1; \
++		elif [ $$mod = "rd98dx45xx_cn9131" ]; then \
++			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y || exit 1; \
+         elif [ $$mod = "rd98dx35xx-x86" ];then \
+ 			make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y CONFIG_KM_MVDMA2=y|| exit 1; \
+ 		elif [ $$mod = "rd98dx35xx" ]; then \
+@@ -81,6 +83,8 @@ override_dh_auto_install:
+ 	(set -e; for mod in $(MODULE_DIRS); do \
+ 		if [ $$mod = "rd98dx35xx_cn9131" ]; then \
+ 			pkg="rd98dx35xx-cn9131"; \
++		elif [ $$mod = "rd98dx45xx_cn9131" ]; then \
++			pkg="rd98dx45xx-cn9131"; \
+ 		else \
+ 			pkg=$$mod; \
+ 		fi; \
+-- 
+2.34.1
+

--- a/files/master/0057-sonic-platform-wistron-rules-for-trixie.patch
+++ b/files/master/0057-sonic-platform-wistron-rules-for-trixie.patch
@@ -1,0 +1,109 @@
+From 9891e6664e457c7aa6e83148e2327e993e847ccb Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Mon, 29 Sep 2025 14:47:08 +0300
+Subject: [PATCH 1/1] sonic-platform-wistron: rules for trixie
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ .../sonic-platform-wistron/debian/rules       | 66 +++++++++----------
+ 1 file changed, 30 insertions(+), 36 deletions(-)
+
+diff --git a/platform/marvell-prestera/sonic-platform-wistron/debian/rules b/platform/marvell-prestera/sonic-platform-wistron/debian/rules
+index 328196af1..fbcb56b25 100755
+--- a/platform/marvell-prestera/sonic-platform-wistron/debian/rules
++++ b/platform/marvell-prestera/sonic-platform-wistron/debian/rules
+@@ -19,38 +19,51 @@ SERVICE_DIR := service
+ PRESTERA_MODULE_SRC := mrvl-prestera/drivers/generic/cpssEnabler/linuxNoKernelModule/drivers
+ 
+ %:
+-	dh $@ --with systemd,python3 --buildsystem=pybuild
++	dh $@ --with python3 --buildsystem=pybuild
+ 
+-clean:
+-	dh_testdir
+-	dh_testroot
++override_dh_auto_clean:
++	(for mod in $(MODULE_DIRS); do \
++		$(MAKE) clean -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --clean -d $${mod}; \
++		fi; \
++		cd $(MOD_SRC_DIR)/$${mod}; \
++		rm -rf $(MRVL_MODULE_DIR)/; \
++		rm -rf *.egg-info/; \
++		rm -f *.whl; \
++		cd $(MOD_SRC_DIR)/; \
++	done)
+ 	dh_clean
+ 
+-build:
++override_dh_auto_configure:
++	(for mod in $(MODULE_DIRS); do \
++		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
++			PYBUILD_NAME=$${mod} pybuild --configure -d $${mod}; \
++		fi; \
++	done)
++
++override_dh_auto_build:
+ 	(for mod in $(MODULE_DIRS); do \
+ 		make modules -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
+ 		cd $(MOD_SRC_DIR)/../$(PRESTERA_MODULE_SRC)/; \
+ 		make clean; \
+ 		make modules -C $(KERNEL_SRC)/build M=`pwd` CONFIG_KM_MVPCI=y CONFIG_KM_MVINT=y || exit 1; \
+-                cp *.ko $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/; \
+-        cd $(MOD_SRC_DIR)/$${mod}; \
++		cp *.ko $(MOD_SRC_DIR)/$${mod}/$(MODULE_DIR)/; \
++		cd $(MOD_SRC_DIR)/$${mod}; \
++		python3 setup.py build; \
+ 		python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}; \
+-        echo "Finished making whl package for $$mod"; \
+ 		cd $(MOD_SRC_DIR); \
+ 	done)
+ 
+-binary: binary-arch binary-indep
+-	# Nothing to do
+ 
+-binary-arch:
+-	# Nothing to do
++override_dh_auto_test:
++	# No tests to run
+ 
+-binary-indep:
+-	dh_testdir
+-	dh_installdirs
++override_dh_usrlocal:
++	# debian/sonic-platform-<>-<>/usr/local/bin/* are already done
+ 
+-	# Custom package commands
+-	(for mod in $(MODULE_DIRS); do \
++override_dh_auto_install:
++	(set -e; for mod in $(MODULE_DIRS); do \
+ 		if [ $$mod = "es1227_54ts" ]; then \
+ 			pkg="es1227-54ts"; \
+ 		elif [ $$mod = "es2227_54ts" ]; then \
+@@ -66,22 +79,3 @@ binary-indep:
+ 		cp $(MOD_SRC_DIR)/$${mod}/$(SERVICE_DIR)/*.service debian/sonic-platform-$${pkg}/lib/systemd/system/; \
+ 		#python3 $${mod}/setup.py install --root=$(MOD_SRC_DIR)/debian/sonic-platform-$${pkg} --install-layout=deb; \
+ 	done)
+-
+-	# Resuming debhelper scripts
+-	dh_testroot
+-	dh_install
+-	dh_installchangelogs
+-	dh_installdocs
+-	dh_systemd_enable
+-	dh_installinit
+-	dh_systemd_start
+-	dh_link
+-	dh_fixperms
+-	dh_compress
+-	dh_strip
+-	dh_installdeb
+-	dh_gencontrol
+-	dh_md5sums
+-	dh_builddeb
+-
+-.PHONY: build binary binary-arch binary-indep clean
+-- 
+2.34.1
+

--- a/files/master/series_marvell-prestera_amd64
+++ b/files/master/series_marvell-prestera_amd64
@@ -3,5 +3,12 @@
 0001-Falcon-usb-disk-hung_task-WA.patch|sonic-buildimage
 0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
-0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell
+21506-submodule-sonic-platform-marvell-add-AC5P-marvell_rd.patch|sonic-buildimage
+21506-add-AC5P-marvell_rd98DX45xx_cn9131.patch|sonic-buildimage
+0002-platform-prestera-fix-support-for-AC5P-RD-mmcblk.patch|sonic-buildimage
+0052-platform-marvell-prestera-sonic-platform-nokia-rules7215.patch|sonic-buildimage
 0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera
+0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell
+0054-sonic-platform-marvell-rules-rd98dx45xx-rm.patch|platform/marvell-prestera/sonic-platform-marvell
+0055-sonic-platform-marvell-rules-for-trixie.patch|platform/marvell-prestera/sonic-platform-marvell
+0056-sonic-platform-marvell-rules-rd98dx45xx-add.patch|platform/marvell-prestera/sonic-platform-marvell

--- a/files/master/series_marvell-prestera_arm64
+++ b/files/master/series_marvell-prestera_arm64
@@ -9,4 +9,10 @@
 0020-arm64-kdump-support-add-support-in-kdump-config.patch|src/sonic-utilities
 0021-arm64-kdump-support-Install-kdump-utils-for-either-a.patch|sonic-buildimage
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
+0052-platform-marvell-prestera-sonic-platform-nokia-rules7215.patch|sonic-buildimage
 0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera
+0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell
+0054-sonic-platform-marvell-rules-rd98dx45xx-rm.patch|platform/marvell-prestera/sonic-platform-marvell
+0055-sonic-platform-marvell-rules-for-trixie.patch|platform/marvell-prestera/sonic-platform-marvell
+0056-sonic-platform-marvell-rules-rd98dx45xx-add.patch|platform/marvell-prestera/sonic-platform-marvell
+0057-sonic-platform-wistron-rules-for-trixie.patch|sonic-buildimage

--- a/files/master/series_marvell-prestera_armhf
+++ b/files/master/series_marvell-prestera_armhf
@@ -2,4 +2,12 @@
 0001-platform-marvell-prestera-fw_setenv-with-without-f.patch|sonic-buildimage
 0012-utilities-restart-mgmt-over-usb-interface-if-not-RUN.patch|src/sonic-utilities
 0001-Remove-unsupported-marvell-board-x86_64-marvell_rd98.patch|sonic-buildimage
+21506-submodule-sonic-platform-marvell-add-AC5P-marvell_rd.patch|sonic-buildimage
+21506-add-AC5P-marvell_rd98DX45xx_cn9131.patch|sonic-buildimage
+0002-platform-prestera-fix-support-for-AC5P-RD-mmcblk.patch|sonic-buildimage
+0052-platform-marvell-prestera-sonic-platform-nokia-rules7215.patch|sonic-buildimage
 0053-platform-marvell-prestera-mrvl-prestera-k6.12-mvcpss.patch|platform/marvell-prestera/mrvl-prestera
+0051-platform-prestera-Falcon12.8T-32x100G-profile-sfp.patch|platform/marvell-prestera/sonic-platform-marvell
+0054-sonic-platform-marvell-rules-rd98dx45xx-rm.patch|platform/marvell-prestera/sonic-platform-marvell
+0055-sonic-platform-marvell-rules-for-trixie.patch|platform/marvell-prestera/sonic-platform-marvell
+0056-sonic-platform-marvell-rules-rd98dx45xx-add.patch|platform/marvell-prestera/sonic-platform-marvell


### PR DESCRIPTION
Series of patches updating debian/rules required for TRIXIE build.
Changes are backward compatible to BOOKWORM.
