### PR TITLE
installer write to hung_task_timeout_secs always-ok

### DIFF
--- a/files/master/0031-Falcon-usb-disk-hung_task-WA.patch
+++ b/files/master/0031-Falcon-usb-disk-hung_task-WA.patch
@@ -16,7 +16,7 @@ index 557358fd5..13d2fc3a8 100755
  }
  
  set -e
-+echo 0 > /proc/sys/kernel/hung_task_timeout_secs
++{ echo 0 > /proc/sys/kernel/hung_task_timeout_secs; } 2>/dev/null || true
 +sync
 +echo 3 > /proc/sys/vm/drop_caches
  

--- a/files/trixie/0031-Falcon-usb-disk-hung_task-WA.patch
+++ b/files/trixie/0031-Falcon-usb-disk-hung_task-WA.patch
@@ -16,7 +16,7 @@ index 557358fd5..13d2fc3a8 100755
  }
  
  set -e
-+echo 0 > /proc/sys/kernel/hung_task_timeout_secs
++{ echo 0 > /proc/sys/kernel/hung_task_timeout_secs; } 2>/dev/null || true
 +sync
 +echo 3 > /proc/sys/vm/drop_caches
  

--- a/files/trixie/PR-status-info.txt
+++ b/files/trixie/PR-status-info.txt
@@ -11,6 +11,9 @@ https://github.com/yanmarkman/sonic-buildimage/tree/ym-trixie-3-marvell-prestera
 https://github.com/yanmarkman/sonic-buildimage/tree/ym-trixie-4-marvell-prestera-for-Nokia
 https://github.com/yanmarkman/sonic-buildimage/tree/ym-trixie-5-marvell-prestera-for-Nokia
 https://github.com/yanmarkman/sonic-buildimage/tree/ym-trixie-6-marvell-prestera-for-Nokia
+------------- all 6 are squashed into 1 PR:
+https://github.com/saiarcot895/sonic-buildimage/pull/44
 
-https://github.com/sonic-net/sonic-buildimage/pull/24278 -- for 1
+------------ 2 Kernel patches are squashed into 1 PR:
+https://github.com/saiarcot895/sonic-linux-kernel/pull/17
 


### PR DESCRIPTION
The original patch disables /proc/sys/kernel/hung_task_timeout_secs=0 for the ONIE-installer.
The hung_task_timeout presence depends upon Kernel-configuration and not always present in Kernel. For example it is present on X86 but by-default does not present on ARM64.
It is desirable to have the patch-set/series for all ARCH-es.

=> make this writing always success even if file does not exist.