### PR TITLE
patches 26-Apr-2026 marvell-prestera

### DIFF
--- a/files/master/0012-marvell-prestera-sai-1.17.1-12.patch
+++ b/files/master/0012-marvell-prestera-sai-1.17.1-12.patch
@@ -1,7 +1,7 @@
 From e3cb639c155fd8a43948d5113c6431313fa4f3d1 Mon Sep 17 00:00:00 2001
 From: Yan Markman <ymarkman@marvell.com>
 Date: Wed, 17 Dec 2025 17:41:07 +0200
-Subject: [PATCH] marvell-prestera: sai-1.17.1-1
+Subject: [PATCH] marvell-prestera: sai-1.17.1-12
 
 Signed-off-by: Yan Markman <ymarkman@marvell.com>
 
@@ -14,13 +14,13 @@ index 49643c401..75a121126 100644
  BRANCH = master
  ifeq ($(CONFIGURED_ARCH),arm64)
 -MRVL_SAI_VERSION = 1.17.1-1
-+MRVL_SAI_VERSION = 1.17.1-2
++MRVL_SAI_VERSION = 1.17.1-12
  else ifeq ($(CONFIGURED_ARCH),armhf)
 -MRVL_SAI_VERSION = 1.17.1-1
-+MRVL_SAI_VERSION = 1.17.1-2
++MRVL_SAI_VERSION = 1.17.1-12
  else
 -MRVL_SAI_VERSION = 1.17.1-1
-+MRVL_SAI_VERSION = 1.17.1-2
++MRVL_SAI_VERSION = 1.17.1-12
  endif
  
  MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/

--- a/files/master/series_marvell-prestera
+++ b/files/master/series_marvell-prestera
@@ -1,10 +1,8 @@
 ##-------------------------------------------------------------------------------------
 ## Correct and verified 22-Mar-2026 on SONiC hash
-## 4afba46e2 - 2026-04-11 mssonicbld : [submodule] Update submodule sonic-swss-common to the latest HEAD automatically (#26720)
+## 3706490f8 - 2026-04-25 mssonicbld : [submodule] Update submodule sonic-dash-ha to the latest HEAD automatically (#26949)
 ## Patches with PR:
-## 0011    https://github.com/sonic-net/sonic-buildimage/pull/26440
-## 0012    https://github.com/sonic-net/sonic-utilities/pull/4174 \_squash; pull/4390 on <202511>
-## 0015    https://github.com/sonic-net/sonic-utilities/pull/4174 /
+## 0012    https://github.com/sonic-net/sonic-buildimage/pull/26992 (replaces the #26440)
 ## 0013    https://github.com/sonic-net/sonic-utilities/pull/4419
 ## 0041    https://github.com/sonic-net/sonic-buildimage/pull/25468
 ## 4372    https://github.com/sonic-net/sonic-utilities/pull/4372
@@ -17,15 +15,13 @@
 0041-buildimage-print-each-build-target-on-separated-line.patch     |sonic-buildimage
 
 # From BOOKWORM
-0012-restart-mgmt-over-usb-interface-if-not-RUNNING.patch           |src/sonic-utilities
-0015-Nokia-armhf-config-reload-with-swss-and-sync-restart.patch     |src/sonic-utilities
 0013-sonic_installer-add-sync-before-migration.patch                |src/sonic-utilities
 4372-fast-reboot-warm-reboot-prohibit-from-root.patch               |src/sonic-utilities
 0064-build_templates-marvell-blacklist-with-kempld.patch            |sonic-buildimage
 0031-Falcon-usb-disk-hung_task-WA.patch                             |sonic-buildimage
 
 # TRIXIE specific and strictly-ordered patches
-0011-marvell-prestera-sai-1.17.1-2.patch                            |sonic-buildimage
+0012-marvell-prestera-sai-1.17.1-12.patch                           |sonic-buildimage
 0041-grub2-grub_cmd_sleep-increase-tolerance-to-14sec.patch         |sonic-buildimage
 
 # Strictly ordered performance/stability patch-SET ----------------------------


### PR DESCRIPTION
SONIC-base:
3706490f8 - 2026-04-25 mssonicbld : [submodule] Update submodule sonic-dash-ha to the latest HEAD automatically (#26949)

The https://github.com/sonic-net/sonic-utilities/pull/4174 is merged, so remove
0012-restart-mgmt-over-usb-interface-if-not-RUNNING.patch         |src/sonic-utilities
0015-Nokia-armhf-config-reload-with-swss-and-sync-restart.patch |src/sonic-utilities

Replace the
0011-marvell-prestera-sai-1.17.1-2.patch  (preliminary P7.0.1)
with the
0012-marvell-prestera-sai-1.17.1-12.patch (P7.0.0 with ACL-fix)