### PR TITLE
(28070)device: Nokia-7215 sai.profile: createSwitchTimeout=180s

### DIFF
--- a/files/202511/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
+++ b/files/202511/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
@@ -1,0 +1,41 @@
+From 645abcba4a82b318a06a27debf553aba30e0512e Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Wed, 24 Jun 2026 11:47:43 +0300
+Subject: [PATCH 1/1] device: Nokia-7215 sai.profile: createSwitchTimeout=180s
+
+PROBLEM:
+Nokia-7214/armhf/AC3x has long time for SONIC/swss/syncd
+start and "restart".
+"orinary", the existing createSwitchTimeout=120s is enough
+for reboot and for "config reload"(e.g. restart).
+But sometimes after "deploy-minigraph + config reload"
+the 120s is Not enough.
+
+syslog in that case:
+swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
+                failure in create operation, SAI API: SAI_API_SWITCH
+
+SOLUTION:
+Increase createSwitchTimeout in the sai.profile from 120s to 180s.
+
+NOTE: Needed and done for One slow/weak "device/nokia armhf"
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+index 61ad9bae0..2fdf55a1e 100644
+--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
++++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+@@ -2,5 +2,5 @@ mode=1
+ hwId=et6448m
+ SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/profile.ini
+ switchProfile=/usr/share/sonic/hwsku/SAI-M0-48x1G-4x10G.xml
+-createSwitchTimeout=120
++createSwitchTimeout=180
+ customEVlanUpdate=1
+-- 
+2.34.1
+

--- a/files/202511/series_marvell-prestera
+++ b/files/202511/series_marvell-prestera
@@ -4,6 +4,7 @@
 0064-build_templates-marvell-blacklist-with-kempld.patch            |sonic-buildimage
 0031-Falcon-usb-disk-hung_task-WA.patch                             |sonic-buildimage
 
+28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch  |sonic-buildimage
 0041-grub2-grub_cmd_sleep-increase-tolerance-to-14sec.patch         |sonic-buildimage
 0043-marvell-prestera-rpc-pin-ptf_nn_agent.py-to-use-nnpy.patch     |sonic-buildimage
 

--- a/files/202605/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
+++ b/files/202605/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
@@ -1,0 +1,41 @@
+From 645abcba4a82b318a06a27debf553aba30e0512e Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Wed, 24 Jun 2026 11:47:43 +0300
+Subject: [PATCH 1/1] device: Nokia-7215 sai.profile: createSwitchTimeout=180s
+
+PROBLEM:
+Nokia-7214/armhf/AC3x has long time for SONIC/swss/syncd
+start and "restart".
+"orinary", the existing createSwitchTimeout=120s is enough
+for reboot and for "config reload"(e.g. restart).
+But sometimes after "deploy-minigraph + config reload"
+the 120s is Not enough.
+
+syslog in that case:
+swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
+                failure in create operation, SAI API: SAI_API_SWITCH
+
+SOLUTION:
+Increase createSwitchTimeout in the sai.profile from 120s to 180s.
+
+NOTE: Needed and done for One slow/weak "device/nokia armhf"
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+index 61ad9bae0..2fdf55a1e 100644
+--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
++++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+@@ -2,5 +2,5 @@ mode=1
+ hwId=et6448m
+ SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/profile.ini
+ switchProfile=/usr/share/sonic/hwsku/SAI-M0-48x1G-4x10G.xml
+-createSwitchTimeout=120
++createSwitchTimeout=180
+ customEVlanUpdate=1
+-- 
+2.34.1
+

--- a/files/202605/series_marvell-prestera
+++ b/files/202605/series_marvell-prestera
@@ -3,6 +3,7 @@
 ## 0013    https://github.com/sonic-net/sonic-utilities/pull/4419
 ## 0041    https://github.com/sonic-net/sonic-buildimage/pull/25468
 ## 0064    https://github.com/sonic-net/sonic-buildimage/pull/26484
+## 28070   https://github.com/sonic-net/sonic-buildimage/pull/28070
 ##-------------------------------------------------------------------------------------
 
 # Apply optional and oldest first, but newest - last for easy debug
@@ -14,6 +15,7 @@
 0064-build_templates-marvell-blacklist-with-kempld.patch            |sonic-buildimage
 0031-Falcon-usb-disk-hung_task-WA.patch                             |sonic-buildimage
 
+28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch  |sonic-buildimage
 0041-grub2-grub_cmd_sleep-increase-tolerance-to-14sec.patch         |sonic-buildimage
 0043-marvell-prestera-rpc-pin-ptf_nn_agent.py-to-use-nnpy.patch     |sonic-buildimage
 

--- a/files/master/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
+++ b/files/master/28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch
@@ -1,0 +1,41 @@
+From 645abcba4a82b318a06a27debf553aba30e0512e Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Wed, 24 Jun 2026 11:47:43 +0300
+Subject: [PATCH 1/1] device: Nokia-7215 sai.profile: createSwitchTimeout=180s
+
+PROBLEM:
+Nokia-7214/armhf/AC3x has long time for SONIC/swss/syncd
+start and "restart".
+"orinary", the existing createSwitchTimeout=120s is enough
+for reboot and for "config reload"(e.g. restart).
+But sometimes after "deploy-minigraph + config reload"
+the 120s is Not enough.
+
+syslog in that case:
+swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
+                failure in create operation, SAI API: SAI_API_SWITCH
+
+SOLUTION:
+Increase createSwitchTimeout in the sai.profile from 120s to 180s.
+
+NOTE: Needed and done for One slow/weak "device/nokia armhf"
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+index 61ad9bae0..2fdf55a1e 100644
+--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
++++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+@@ -2,5 +2,5 @@ mode=1
+ hwId=et6448m
+ SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/profile.ini
+ switchProfile=/usr/share/sonic/hwsku/SAI-M0-48x1G-4x10G.xml
+-createSwitchTimeout=120
++createSwitchTimeout=180
+ customEVlanUpdate=1
+-- 
+2.34.1
+

--- a/files/master/series_marvell-prestera
+++ b/files/master/series_marvell-prestera
@@ -3,6 +3,7 @@
 ## 0013    https://github.com/sonic-net/sonic-utilities/pull/4419
 ## 0041    https://github.com/sonic-net/sonic-buildimage/pull/25468
 ## 0064    https://github.com/sonic-net/sonic-buildimage/pull/26484
+## 28070   https://github.com/sonic-net/sonic-buildimage/pull/28070
 ##-------------------------------------------------------------------------------------
 
 # Apply optional and oldest first, but newest - last for easy debug
@@ -14,6 +15,7 @@
 0064-build_templates-marvell-blacklist-with-kempld.patch            |sonic-buildimage
 0031-Falcon-usb-disk-hung_task-WA.patch                             |sonic-buildimage
 
+28070-device-Nokia-7215-sai.profile-createSwitchTimeout-180s.patch  |sonic-buildimage
 0041-grub2-grub_cmd_sleep-increase-tolerance-to-14sec.patch         |sonic-buildimage
 0043-marvell-prestera-rpc-pin-ptf_nn_agent.py-to-use-nnpy.patch     |sonic-buildimage
 


### PR DESCRIPTION
IPBUSW-106861
https://github.com/sonic-net/sonic-buildimage/pull/28070

PROBLEM:
Nokia-7214/armhf/AC3x has long time for SONIC/swss/syncd start and "restart".
"orinary", the existing createSwitchTimeout=120s is enough for reboot and for "config reload"(e.g. restart).
But sometimes after "deploy-minigraph + config reload" the 120s is Not enough.

syslog in that case:
swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
                    failure in create operation, SAI API: SAI_API_SWITCH

SOLUTION:
Increase createSwitchTimeout in the sai.profile from 120s to 180s.

NOTE: Needed and done for One slow/weak "device/nokia armhf"